### PR TITLE
Add Atomic Simulation Environment (ase) as a conda dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: tst_env
 channels:
   - defaults
   - rmg
+  - conda-forge
 dependencies:
   - rmg ==2.1.0
-
+  - ase


### PR DESCRIPTION
from channel conda-forge