### PR TITLE
Addressing error when identifying non H-Abstraction reactions

### DIFF
--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -50,6 +50,7 @@ from rmgpy.reaction import Reaction as RMGReaction
 from rmgpy.reaction import ReactionError
 from rmgpy.kinetics import PDepArrhenius, PDepKineticsModel
 from rmgpy.data.rmg import RMGDatabase
+from rmgpy.exceptions import ActionError
 
 import autotst
 from autotst.data.base import DistanceData, TransitionStateDepository, TSGroups, TransitionStates
@@ -251,7 +252,7 @@ class Reaction():
 
             self._distance_data.distances["d13"] -= self._distance_data.uncertainties["d13"] / 2
 
-        logging.info("The distance data is as follows: \n{}".format(
+        logging.info("The distance data is as follows: {}".format(
             self._distance_data))
 
         return self._distance_data
@@ -359,11 +360,11 @@ class Reaction():
                     rmg_products.append(prod.molecule)
                 elif isinstance(prod, RMGMolecule):
                     rmg_products.append([prod])
-
             test_reactants = []
             test_products = []
             if len(rmg_reactants) == 1:
-                test_reactants = rmg_reactants
+                for l1 in rmg_reactants[0]:
+                    test_reactants.append([l1])
             elif len(rmg_reactants) == 2:
                 l1, l2 = rmg_reactants
                 for i in l1:
@@ -371,30 +372,54 @@ class Reaction():
                         test_reactants.append([i, j])
 
             if len(rmg_products) == 1:
-                test_reactants = rmg_products
+                for l1 in rmg_products[0]:
+                    test_products.append([l1])
             elif len(rmg_products) == 2:
                 l1, l2 = rmg_products
                 for i in l1:
                     for j in l2:
                         test_products.append([i, j])
+
+            reacts = test_reactants[:]
+            prods = test_products[:]
             for name, family in list(self.rmg_database.kinetics.families.items()):
+                logging.info("Trying to match {} to {}".format(self.rmg_reaction, family))
+
                 if match:
-                    break
+                    continue
+                
+                test_reactants = reacts[:]
+                test_products = prods[:]
                 for test_reactant in test_reactants:
-                    for test_products in test_products:
+                    for test_product in test_products:
 
                         if match:
                             continue
 
                         test_reaction = RMGReaction(
-                            reactants=test_reactant, products=test_products)
+                            reactants=test_reactant, products=test_product)
 
-                        labeled_r, labeled_p = family.getLabeledReactantsAndProducts(
-                            test_reaction.reactants, test_reaction.products)
+                        try:
+                            labeled_r, labeled_p = family.getLabeledReactantsAndProducts(
+                                test_reaction.reactants, test_reaction.products)
+                            if not (labeled_r and labeled_p):
+                                raise ActionError
+                        except (ValueError, ActionError, IndexError):
+                            try: 
+                                # Trying the reverse reaction if the forward reaction doesn't work
+                                # This is useful for R_Addition reactions
+                                labeled_r, labeled_p = family.getLabeledReactantsAndProducts(
+                                    test_reaction.products, test_reaction.reactants)
+                            except (ValueError, ActionError, IndexError):
+                               continue
+                            
+
                         if not (labeled_r and labeled_p):
+                            labeled_r, labeled_p = family.getLabeledReactantsAndProducts(
+                                test_reaction.products, test_reaction.reactants)
                             continue
 
-                        if ((len(labeled_r) > 0) and (len(labeled_p) > 0)):
+                        if ((len(labeled_r) > 0) and (len(labeled_p) > 0)) and (self.rmg_reaction.isIsomorphic(test_reaction)):
                             logging.info(
                                 "Matched reaction to {} family".format(name))
 
@@ -402,15 +427,19 @@ class Reaction():
                             labeled_products = deepcopy(labeled_p)
                             test_reaction.reactants = labeled_r[:]
                             test_reaction.products = labeled_p[:]
-                            logging.info("\n{}".format(labeled_r))
-                            logging.info("\n{}".format(labeled_p))
+                            logging.info("{}".format(labeled_r))
+                            logging.info("{}".format(labeled_p))
                             match = True
+                            final_family = family
                             final_name = name
-                            break
+                            
         assert match, "Could not idetify labeled reactants and products"
-
-        reaction_list = self.rmg_database.kinetics.generate_reactions(
+        #try: 
+        reaction_list = final_family.generateReactions(
             test_reaction.reactants, test_reaction.products)
+        #except KeyError:
+        #    reaction_list = None
+        #    logging.info("For some reason, RMG is having trouble generating reactions for {}".format(test_reaction))
 
         assert reaction_list, "Could not match a reaction to a reaction family..."
 
@@ -420,7 +449,7 @@ class Reaction():
                 reaction.products = labeled_products
                 break
         self.rmg_reaction = reaction
-        self.reaction_family = name
+        self.reaction_family = final_name
         return self.rmg_reaction, self.reaction_family
 
     def get_label(self):

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -343,6 +343,7 @@ class Reaction():
                     test_reaction.reactants = labeled_r[:]
                     test_reaction.products = labeled_p[:]
                     match = True
+                    final_family = family
                     final_name = name
                     break
 
@@ -431,6 +432,7 @@ class Reaction():
                             logging.info("{}".format(labeled_p))
                             match = True
                             final_family = family
+                            print final_family
                             final_name = name
                             
         assert match, "Could not idetify labeled reactants and products"

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -687,9 +687,10 @@ class TS(Conformer):
             if not rd_copy.GetBondBetweenAtoms(lbl1, lbl2):
                 rd_copy.AddBond(lbl1, lbl2,
                                 order=rdkit.Chem.rdchem.BondType.SINGLE)
-            else:
+            elif not rd_copy.GetBondBetweenAtoms(lbl2, lbl3):
                 rd_copy.AddBond(lbl2, lbl3,
                                 order=rdkit.Chem.rdchem.BondType.SINGLE)
+            
 
             self._pseudo_geometry = rd_copy
 

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -329,9 +329,12 @@ class Reaction():
             for name, family in list(self.rmg_database.kinetics.families.items()):
                 if match:
                     break
-
-                labeled_r, labeled_p = family.getLabeledReactantsAndProducts(
-                    test_reaction.reactants, test_reaction.products)
+                try:
+                    labeled_r, labeled_p = family.getLabeledReactantsAndProducts(
+                        test_reaction.reactants, test_reaction.products)
+                except ValueError:
+                    continue
+                    
                 if not (labeled_r and labeled_p):
                     continue
 
@@ -404,6 +407,7 @@ class Reaction():
                             labeled_r, labeled_p = family.getLabeledReactantsAndProducts(
                                 test_reaction.reactants, test_reaction.products)
                             if not (labeled_r and labeled_p):
+                                logging.info("Unable to determine a reaction for the forward direction. Trying the reverse direction.")
                                 raise ActionError
                         except (ValueError, ActionError, IndexError):
                             try: 

--- a/autotst/reactionTest.py
+++ b/autotst/reactionTest.py
@@ -182,6 +182,17 @@ class TestReaction(unittest.TestCase):
         self.assertIsInstance(self.reaction2.ts["forward"][0], TS)
         self.assertIsInstance(self.reaction2.ts["reverse"][0], TS)
 
+    def test_reaction_families(self):
+        # R_Addition_MultipleBond
+        reaction = Reaction("C#C+[OH]_[CH]=CO")
+        _, family = reaction.get_labeled_reaction()
+        self.assertEqual(family.lower(), "R_Addition_MultipleBond".lower())
+        
+        # intra_H_migration
+        reaction = Reaction("C[CH]O_CC[O]")
+        _, family = reaction.get_labeled_reaction()
+        self.assertEqual(family.lower(), "intra_H_migration".lower())
+
 class TestTS(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Upon working with the recent master, I was running into issues trying to get labeled transition states for intra_H_migration and R_Addition_MultipleBond. When using the RMG-Database to identify labeled reactions, there were times where reactions of a known family were unable to be matched to that family within the AutoTST code. I performed the following changes to the code:

- autotst.reaction.Reaction:
  - `get_labeled_reaction`
    - fixed a bug when trying to match unimolecular reactions
    - added attempting to match a reverse reaction to a reaction family if the forward reaction fails to match a reaction family
    - improved exception handling when reactions fail to match a supported reaction family
- autotst.reaction.TS:
  - `get_rdkit_mol`
    - removed the addition of a pseudo bond between reaction atoms if the reaction is unimolecular

This was tested on the Sarathy's butanol model to try and identify the 1117 reactions reported in the AutoTST 1.0 paper. From this we were able to identify all 1117 reactions and correctly identify their reaction families. The testing script (reaction-debugging.py.txt) is attached.


[reaction-debugging.py.txt](https://github.com/ReactionMechanismGenerator/AutoTST/files/3273041/reaction-debugging.py.txt)
[butanol-reactions.txt](https://github.com/ReactionMechanismGenerator/AutoTST/files/3273042/butanol-reactions.txt)
