### PR TITLE
Systematic - RDKIT RMSD / multiplicity

### DIFF
--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -298,25 +298,20 @@ def systematic_search(conformer,
     logging.info("We have identified {} unique conformers for {}".format(
         len(df.conformer), conformer))
 
-    if (multiplicity) and (conformer.rmg_molecule.multiplicity > 2):
-        mulitplicities = []
-        rads_unpaired = [atom.radicalElectrons for atom in conformer.rmg_molecule.getRadicalAtoms()]
-        rads_paired = [r % 2 for r in rads_unpaired]
-        radical_combos = [r for r in itertools.product(range(2),repeat=len(rads_unpaired))]
-        for combo in radical_combos:
-            mult = 1
-            for x in zip(rads_unpaired,rads_paired,combo):
-                mult += x[x[-1]]
-            mulitplicities.append(mult)
-        mulitplicities = list(set(mulitplicities))
+    if conformer.rmg_molecule.multiplicity > 2:
+        rads = conformer.rdkit_molecule.getRadicalCount()
+        if rads % 2 == 0:
+            multiplicities = range(1,rads+2,2)
+        else:
+            multiplicities = range(2,rads+2,2)
     else:
-        mulitplicities = [conformer.rmg_molecule.multiplicity]
+        multiplicities = [conformer.rmg_molecule.multiplicity]
 
     confs = []
     i = 0
     for conf in df.conformer:
         if multiplicity:
-            for mult in mulitplicities:
+            for mult in multiplicities:
                 conf_copy = conf.copy()
                 conf_copy.index = i
                 conf_copy.rmg_molecule.multiplicity = mult

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -108,7 +108,7 @@ def find_all_combos(
 def systematic_search(conformer,
                       delta=float(120),
                       energy_cutoff = 10.0, #kcal/mol
-                      rmsd_cutoff = 1.0, #angstroms
+                      rmsd_cutoff = 0.5, #angstroms
                       cistrans = True,
                       chiral_centers = True,
                       multiplicity = False,
@@ -125,7 +125,28 @@ def systematic_search(conformer,
     Returns:
     - confs (list): a list of unique `Conformer` objects within 1 kcal/mol of the lowest energy conformer determined
     """
-    # Takes each of the molecule objects
+    
+    rmsd_cutoff_options = {
+        'loose' : 1.0,
+        'default': 0.5,
+        'tight': 0.1
+    }
+
+    energy_cutoff_options = {
+        'high' : 50.0,
+        'default' : 10.0,
+        'low' : 5.0
+    }
+
+    if isinstance(rmsd_cutoff,str):
+        rmsd_cutoff = rmsd_cutoff.lower()
+        assert rmsd_cutoff in rmsd_cutoff_options.keys(), 'rmsd_cutoff options are loose, default, and tight'
+        rmsd_cutoff = rmsd_cutoff_options[rmsd_cutoff]
+
+    if isinstance(energy_cutoff,str):
+        energy_cutoff = energy_cutoff.lower()
+        assert energy_cutoff in energy_cutoff_options.keys(), 'energy_cutoff options are low, default, and high'
+        energy_cutoff = energy_cutoff_options[energy_cutoff]
     
     if not isinstance(conformer, TS):
         reference_mol = conformer.rmg_molecule.copy(deep=True)

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -49,7 +49,7 @@ from autotst.conformer.utilities import get_energy, find_terminal_torsions
 
 def find_all_combos(
         conformer,
-        delta=float(60),
+        delta=float(120),
         cistrans=True,
         chiral_centers=True):
     """
@@ -102,9 +102,7 @@ def find_all_combos(
 
 
 def systematic_search(conformer,
-                      delta=float(60),
-                      cistrans=True,
-                      chiral_centers=True,
+                      delta = float(120),
                       ):
     """
     Perfoms a systematic conformer analysis of a `Conformer` or a `TS` object

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -43,17 +43,15 @@ from ase.optimize import BFGS
 from ase import units
 from ase.constraints import FixBondLengths
 
+from rdkit.Chem import rdMolAlign
+
+from rmgpy.exceptions import AtomTypeError
+from rmgpy.molecule import Molecule
+
 import autotst
 from autotst.species import Conformer
 from autotst.reaction import TS
 from autotst.conformer.utilities import get_energy, find_terminal_torsions
-
-from rmgpy.molecule import Molecule
-
-from rdkit.Chem import rdMolAlign
-
-from rmgpy.exceptions import AtomTypeError
-
 
 def find_all_combos(
         conformer,

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -111,7 +111,7 @@ def systematic_search(conformer,
                       rmsd_cutoff = 1.0, #angstroms
                       cistrans = True,
                       chiral_centers = True,
-                      multiplicity = True
+                      multiplicity = False,
                       ):
     """
     Perfoms a systematic conformer analysis of a `Conformer` or a `TS` object
@@ -328,7 +328,7 @@ def systematic_search(conformer,
     redundant = list(set(redundant))
     df.drop(df.index[redundant], inplace=True)
 
-    if conformer.rmg_molecule.multiplicity > 2:
+    if multiplicity and conformer.rmg_molecule.multiplicity > 2:
         rads = conformer.rmg_molecule.getRadicalCount()
         if rads % 2 == 0:
             multiplicities = range(1,rads+2,2)

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -48,6 +48,8 @@ from autotst.species import Conformer
 from autotst.reaction import TS
 from autotst.conformer.utilities import get_energy, find_terminal_torsions
 
+from rmgpy.molecule import Molecule
+
 from rdkit.Chem import rdMolAlign
 
 
@@ -104,11 +106,11 @@ def find_all_combos(
 
 
 def systematic_search(conformer,
-                      delta = float(120),
+                      delta=float(120),
                       energy_cutoff = 10.0, #kcal/mol
-                      rmsd_cutoff = 1.2, #angstroms
-                      cistrans= True,
-                      chiral_centers= True,
+                      rmsd_cutoff = 1.0, #angstroms
+                      cistrans = True,
+                      chiral_centers = True,
                       multiplicity = True
                       ):
     """
@@ -124,6 +126,98 @@ def systematic_search(conformer,
     - confs (list): a list of unique `Conformer` objects within 1 kcal/mol of the lowest energy conformer determined
     """
     # Takes each of the molecule objects
+
+    reference_mol = conformer.rmg_molecule.copy(deep=True)
+    reference_mol = reference_mol.toSingleBonds()
+    manager = Manager()
+    return_dict = manager.dict()
+
+    def opt_conf(conformer, calculator, i, rmsd_cutoff):
+        """
+        A helper function to optimize the geometry of a conformer.
+        Only for use within this parent function
+        """
+
+        labels = []
+        for bond in conformer.get_bonds():
+            labels.append(bond.atom_indices)
+    
+        if isinstance(conformer, TS):
+            label = conformer.reaction_label
+            ind1 = conformer.rmg_molecule.getLabeledAtom("*1").sortingLabel
+            ind2 = conformer.rmg_molecule.getLabeledAtom("*3").sortingLabel
+            labels.append([ind1, ind2])
+            type = 'ts'
+        else:
+            label = conformer.smiles
+            type = 'species'
+
+        if isinstance(calc, FileIOCalculator):
+            if calculator.directory:
+                directory = calculator.directory 
+            else: 
+                directory = 'conformer_logs'
+            calculator.label = "{}_{}".format(conformer.smiles, i)
+            calculator.directory = os.path.join(directory, label,'{}_{}'.format(conformer.smiles, i))
+            if not os.path.exists(calculator.directory):
+                try:
+                    os.makedirs(calculator.directory)
+                except OSError:
+                    logging.info("An error occured when creating {}".format(calculator.directory))
+
+            calculator.atoms = conformer.ase_molecule
+
+        conformer.ase_molecule.set_calculator(calculator)
+        opt = BFGS(conformer.ase_molecule, logfile=None)
+
+        if type == 'species':
+            if isinstance(i,int):
+                c = FixBondLengths(labels)
+                conformer.ase_molecule.set_constraint(c)
+            try:
+                opt.run(steps=1e6)
+            except RuntimeError:
+                logging.info("Optimization failed...we will use the unconverged geometry")
+                pass
+        
+        if type == 'ts':
+            c = FixBondLengths(labels)
+            conformer.ase_molecule.set_constraint(c)
+            try:
+                opt.run(fmax=0.20, steps=1e6)
+            except RuntimeError:
+                logging.info("Optimization failed...we will use the unconverged geometry")
+                pass
+            
+        conformer.update_coords_from("ase")
+        rmg_mol = Molecule()
+        rmg_mol.fromXYZ(
+            conformer.ase_molecule.arrays["numbers"],
+            conformer.ase_molecule.arrays["positions"]
+        )
+
+        if not rmg_mol.isIsomorphic(reference_mol):
+            logging.info("{}_{} is not isomorphic with reference mol".format(conformer,str(i)))
+            return False
+
+        energy = get_energy(conformer)
+        conformer.energy = energy
+        if len(return_dict)>0:
+            conformer_copy = conformer.copy()
+            for index,conf in return_dict.items():
+                conf_copy = conf.copy()
+                rmsd = rdMolAlign.GetBestRMS(conformer_copy.rdkit_molecule,conf_copy.rdkit_molecule)
+                if rmsd <= rmsd_cutoff:
+                    return True
+        if str(i) != 'ref':
+            return_dict[i] = conformer
+        return True
+
+    if not isinstance(conformer,TS):
+        calc = conformer.ase_molecule.get_calculator()
+        reference_conformer = conformer.copy()
+        if opt_conf(reference_conformer, calc, 'ref', rmsd_cutoff):
+            conformer = reference_conformer
 
     combos = find_all_combos(
         conformer,
@@ -180,75 +274,6 @@ def systematic_search(conformer,
   
         conformers[index] = conformer.copy()
 
-    logging.info(
-        "There are {} unique conformers generated".format(len(conformers)))
-
-    def opt_conf(conformer, calculator, i, rmsd_cutoff):
-        """
-        A helper function to optimize the geometry of a conformer.
-        Only for use within this parent function
-        """
-
-        if isinstance(conformer, TS):
-            labels = []
-            for bond in conformer.get_bonds():
-                labels.append(bond.atom_indices)
-            label = conformer.reaction_label
-            ind1 = conformer.rmg_molecule.getLabeledAtom("*1").sortingLabel
-            ind2 = conformer.rmg_molecule.getLabeledAtom("*3").sortingLabel
-            labels.append([ind1, ind2])
-            type = 'ts'
-        else:
-            label = conformer.smiles
-            type = 'species'
-
-        if isinstance(calc, FileIOCalculator):
-            if calculator.directory:
-                directory = calculator.directory 
-            else: 
-                directory = 'conformer_logs'
-            calculator.label = "{}_{}".format(conformer.smiles, i)
-            calculator.directory = os.path.join(directory, label,'{}_{}'.format(conformer.smiles, i))
-            if not os.path.exists(calculator.directory):
-                try:
-                    os.makedirs(calculator.directory)
-                except OSError:
-                    logging.info("An error occured when creating {}".format(calculator.directory))
-
-            calculator.atoms = conformer.ase_molecule
-
-        conformer.ase_molecule.set_calculator(calculator)
-        opt = BFGS(conformer.ase_molecule, logfile=None)
-
-        if type == 'species':
-            try:
-                opt.run(steps=1e6)
-            except RuntimeError:
-                logging.info("Optimization failed...we will use the unconverged geometry")
-                pass
-        
-        if type == 'ts':
-            c = FixBondLengths(labels)
-            conformer.ase_molecule.set_constraint(c)
-            try:
-                opt.run(fmax=0.20, steps=1e6)
-            except RuntimeError:
-                logging.info("Optimization failed...we will use the unconverged geometry")
-                pass
-            
-        conformer.update_coords_from("ase")
-        energy = get_energy(conformer)
-        conformer.energy = energy
-        if len(return_dict)>0:
-            for index,conf in return_dict.items():
-                rmsd = rdMolAlign.GetBestRMS(conformer.rdkit_molecule,conf.rdkit_molecule)
-                if rmsd <= rmsd_cutoff:
-                    return
-        return_dict[i] = conformer
-        
-
-    manager = Manager()
-    return_dict = manager.dict()
 
     processes = []
     for i, conf in list(conformers.items()):
@@ -272,7 +297,6 @@ def systematic_search(conformer,
 
             process.start()
             active_processes[i] = process
-
     complete = np.zeros_like(active_processes, dtype=bool)
     while not np.all(complete):
         for i, p in enumerate(active_processes):
@@ -288,18 +312,19 @@ def systematic_search(conformer,
             units.eV)].sort_values("energy").reset_index(drop=True)
 
     redundant = []
+    conformer_copies = [conf.copy() for conf in df.conformer]
     for i,j in itertools.combinations(range(len(df.conformer)),2):
-        rmsd = rdMolAlign.GetBestRMS(df.conformer[i].rdkit_molecule,df.conformer[j].rdkit_molecule)
+        copy_1 = conformer_copies[i].rdkit_molecule
+        copy_2 = conformer_copies[j].rdkit_molecule
+        rmsd = rdMolAlign.GetBestRMS(copy_1,copy_2)
         if rmsd <= rmsd_cutoff:
             redundant.append(j)
 
     redundant = list(set(redundant))
     df.drop(df.index[redundant], inplace=True)
-    logging.info("We have identified {} unique conformers for {}".format(
-        len(df.conformer), conformer))
 
     if conformer.rmg_molecule.multiplicity > 2:
-        rads = conformer.rdkit_molecule.getRadicalCount()
+        rads = conformer.rmg_molecule.getRadicalCount()
         if rads % 2 == 0:
             multiplicities = range(1,rads+2,2)
         else:
@@ -321,5 +346,8 @@ def systematic_search(conformer,
             conf.index = i
             confs.append(conf)
             i += 1
+
+    logging.info("We have identified {} unique, low-energy conformers for {}".format(
+        len(confs), conformer))
     
     return confs

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -222,7 +222,7 @@ def systematic_search(conformer,
 
         if type == 'species':
             try:
-                opt.run(steps=1000)
+                opt.run(steps=1e6)
             except RuntimeError:
                 logging.info("Optimization failed...we will use the unconverged geometry")
                 pass

--- a/autotst/conformer/systematicTest.py
+++ b/autotst/conformer/systematicTest.py
@@ -36,8 +36,9 @@ from ase.calculators.emt import EMT
 class TestSystematic(unittest.TestCase):
 
     def setUp(self):
-        self.conformer = Conformer("NC(O)C=CC")
-        self.conformer.get_molecules()
+        self.conformer = Conformer("CC(C)C=CC")
+        self.conformer_3rad = Conformer("[C]=[CH]")
+        self.conformer_4rad = Conformer("[C]=[C]")
 
     def test_find_all_combos(self):
          combos = find_all_combos(self.conformer, delta=120, cistrans=True, chiral_centers=True)
@@ -46,9 +47,22 @@ class TestSystematic(unittest.TestCase):
         
     def test_systematic_search(self):
         self.conformer.ase_molecule.set_calculator(EMT())
-        confs = systematic_search(self.conformer, delta=180 )
+        confs = systematic_search(self.conformer, delta=180.0)
         self.assertTrue(0 < len(confs) <= 3)
 
+    def test_systematic_search_multiplicity(self):
+        self.conformer_3rad.ase_molecule.set_calculator(EMT())
+        self.conformer_4rad.ase_molecule.set_calculator(EMT())
+        confs_3rad = systematic_search(self.conformer_3rad, delta=180.0, energy_cutoff = "default",
+                                      rmsd_cutoff = "default", multiplicity = True)
+        confs_4rad = systematic_search(self.conformer_4rad, delta=180.0, energy_cutoff = "high",
+                                      rmsd_cutoff = "loose", multiplicity = True)
+        self.assertTrue(confs_3rad[0].rmg_molecule.multiplicity == 2)
+        self.assertTrue(confs_3rad[1].rmg_molecule.multiplicity == 4)
+        self.assertTrue(confs_4rad[0].rmg_molecule.multiplicity == 1)
+        self.assertTrue(confs_4rad[1].rmg_molecule.multiplicity == 3)
+        self.assertTrue(confs_4rad[2].rmg_molecule.multiplicity == 5)
+        
 
 if __name__ == "__main__":
     unittest.main(testRunner=unittest.TextTestRunner(verbosity=2))

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ channels:
   - anaconda
   - conda-forge
 dependencies:
-  - rmg
+  - rmg == 2.4.0
   - ase
   - cclib == 1.5.3
   - py3dmol

--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,6 @@ dependencies:
   - ase
   - cclib == 1.5.3
   - py3dmol
-  - rdkit
+  - rdkit == 2018.09.3.0
   - nose
   - codecov


### PR DESCRIPTION
Three major changes:
1. added different optimization schemes for species and TSs
- now species are optimized without fixed bond constraints
- species and ts's are run down hill, if they do not converge, the last unconverted coordinates will be used
2. added RDkit `GetBestRMS` method (see https://www.rdkit.org/docs/source/rdkit.Chem.rdMolAlign.html)
- it will align the conformers taking sym into account and is independent of atom numbering (it does, however, leave the rdkit mol object in an aligned state which may change atom indexing for rdkit mol compared to rmg and ase mols)
- method is used during and after conformer generation.  It is used after because if conformers generation is performed in parallel, identical confs created at the same time may be missed.
3. implemented optional multiplicity variation for conformers
- if there is more than 1 radical on an atom, rmg calculates multiplicity by assuming they are unpaired.  However, the lowest energy conformer may not have unpaired radicals. For example the lowest energy conf for `[C]F` is mult 2 (1 pair and 1 unpaired), not mult 4 (3 unpaired). The added multiplicity check will create conformers of difference multiplicity, after conformer optimization.