### PR TITLE
Species and reaction class changes

### DIFF
--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -149,7 +149,7 @@ class Reaction():
         return self._distance_data
 
     @classmethod
-    def load_databases(self, force_reload=False):
+    def load_databases(self, rmg_database_path=None, force_reload=False):
         """
         Load the RMG and AutoTST databases, if they have not already been loaded,
         into the class level variables where they are stored.
@@ -164,10 +164,13 @@ class Reaction():
             return self.rmg_database, self.ts_databases
 
         rmg_database = RMGDatabase()
-        database_path = rmgpy.settings['database.directory']
+
+        if rmg_database_path is None:
+	        database_path = rmgpy.settings['database.directory']
+	    else:
+	        database_path = rmg_database_path
 
         logging.info("Loading RMG database from '{}'".format(database_path))
-
 
         self.possible_families = [  # These families (and only these) will be loaded from both RMG and AutoTST databases
             "R_Addition_MultipleBond",

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -217,8 +217,9 @@ class Reaction():
                 reaction_family)
             global_context = {'__builtins__': None}
             local_context = {'DistanceData': DistanceData}
-            family = rmg_database.kinetics.families[reaction_family]
-            ts_database.family = family
+            family = self.rmg_database.kinetics.families[reaction_family]
+            family_copy = deepcopy(family)
+            ts_database.family = family_copy
             ts_database.load(path, local_context, global_context)
 
             self.ts_databases[reaction_family] = ts_database

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -156,6 +156,8 @@ class Reaction():
 
         Variables:
         - force_reload (bool):if set to True then forces a reload, even if already loaded.
+        - rmg_database_path (str): path to rmg database directory. If None, database will be 
+          loaded from rmgpy.settings['database.directory']
 
         Returns:
         - None
@@ -167,8 +169,8 @@ class Reaction():
 
         if rmg_database_path is None:
 	        database_path = rmgpy.settings['database.directory']
-	    else:
-	        database_path = rmg_database_path
+        else:
+            database_path = rmg_database_path
 
         logging.info("Loading RMG database from '{}'".format(database_path))
 
@@ -927,20 +929,32 @@ class TS(Conformer):
     def get_bonds(self):
         test_conf = Conformer()
         test_conf.rmg_molecule = self.rmg_molecule
-        test_conf.rdkit_molecule = self._pseudo_geometry
+        try:
+            test_conf.rdkit_molecule = self._pseudo_geometry
+        except:
+            self.get_rdkit_mol()
+            test_conf.rdkit_molecule = self._pseudo_geometry
         test_conf.ase_molecule = self.ase_molecule
         return test_conf.get_bonds()
 
     def get_torsions(self):
         test_conf = Conformer()
         test_conf.rmg_molecule = self.rmg_molecule
-        test_conf.rdkit_molecule = self._pseudo_geometry
+        try:
+	        test_conf.rdkit_molecule = self._pseudo_geometry
+        except:
+            self.get_rdkit_mol()
+            test_conf.rdkit_molecule = self._pseudo_geometry
         test_conf.ase_molecule = self.ase_molecule
         return test_conf.get_torsions()
 
     def get_angles(self):
         test_conf = Conformer()
         test_conf.rmg_molecule = self.rmg_molecule
-        test_conf.rdkit_molecule = self._pseudo_geometry
+        try:
+	        test_conf.rdkit_molecule = self._pseudo_geometry
+        except:
+            self.get_rdkit_mol()
+            test_conf.rdkit_molecule = self._pseudo_geometry
         test_conf.ase_molecule = self.ase_molecule
         return test_conf.get_angles()

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -312,6 +312,26 @@ class Conformer():
 
         return self.ase_molecule
 
+    def get_xyz_block(self):
+        """
+        A method for retrieving an XYZ coodinate block from an ase mol
+        
+        Returns:
+            str: XYZ coordinates
+        """
+        
+        if not self.ase_molecule:
+            self.get_ase_mol()
+        ase_molecule = self.ase_molecule
+        symbols = ase_molecule.get_chemical_symbols()
+        natoms = len(symbols)
+        string = ""
+
+        for s, (x, y, z) in zip(symbols, ase_molecule.get_positions()):
+            string += '%-2s %22.15f %22.15f %22.15f\n' % (s, x, y, z)
+        self.xyzcoords = string
+        return string
+
     def get_molecules(self):
         if not self.rmg_molecule:
             self.rmg_molecule = RMGMolecule(SMILES=self.smiles)

--- a/autotst/speciesTest.py
+++ b/autotst/speciesTest.py
@@ -13,6 +13,7 @@ import rmgpy
 from rmgpy.molecule import Molecule as RMGMolecule
 from rmgpy.species import Species as RMGSpecies
 from autotst.geometry import Bond, Angle, Torsion, CisTrans, ChiralCenter
+import numpy as np
 
 class TestConformer(unittest.TestCase):
     def setUp(self):
@@ -66,6 +67,11 @@ class TestConformer(unittest.TestCase):
     def test_calculate_symmetry_number(self):
         self.assertEquals(self.conformer.calculate_symmetry_number(),1)
         os.remove("./CC.symm")
+    def test_get_xyz_block(self):
+        xyz_block = self.conformer.get_xyz_block()
+        positions = self.conformer.ase_molecule.arrays["positions"]
+        for n in range(len(positions)):
+            self.assertTrue((np.array([float(x) for x in xyz_block.split('\n')[n].split()[1:]]) == positions[n]).all())
 
 class TestSpecies(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
- added `get_xyz_block` method for conformer class (used for orca calculator)
- used deep copy of reaction families when loading ts databases
- automatically load databases when importing reaction class