### PR TITLE
Updated symmetry calculations

### DIFF
--- a/autotst/reactionTest.py
+++ b/autotst/reactionTest.py
@@ -246,6 +246,11 @@ class TestTS(unittest.TestCase):
         self.assertEquals(self.ts.symmetry_number, 1)
         self.assertEquals(self.ts2.symmetry_number, 1)
 
+        rxn = Reaction("[CH3]+[OH]_C+[O]") #Expected symmetry number of 3  
+        rxn.get_labeled_reaction() 
+        ts = rxn.ts["forward"][0]
+        self.assertEquals(ts.symmetry_number, 3) 
+
     def test_bounds_matrix(self):
 
         lbl1 = self.ts.rmg_molecule.get_labeled_atoms("*1")[0].sorting_label

--- a/autotst/reactionTest.py
+++ b/autotst/reactionTest.py
@@ -245,7 +245,6 @@ class TestTS(unittest.TestCase):
     def test_symmetry_number(self):
         self.assertEquals(self.ts.symmetry_number, 1)
         self.assertEquals(self.ts2.symmetry_number, 1)
-        os.remove("./CC.[O]O.symm")
 
     def test_bounds_matrix(self):
 

--- a/autotst/reactionTest.py
+++ b/autotst/reactionTest.py
@@ -246,10 +246,15 @@ class TestTS(unittest.TestCase):
         self.assertEquals(self.ts.symmetry_number, 1)
         self.assertEquals(self.ts2.symmetry_number, 1)
 
-        rxn = Reaction("[CH3]+[OH]_C+[O]") #Expected symmetry number of 3  
-        rxn.get_labeled_reaction() 
-        ts = rxn.ts["forward"][0]
-        self.assertEquals(ts.symmetry_number, 3) 
+        reactions_to_test = {
+            "[CH3]+[OH]_C+[O]" : 3,
+            # TODO add other reactions here
+        }
+        for reaction_string, expected_symmetry in reactions_to_test.items():
+            rxn = Reaction(reaction_string)
+            rxn.get_labeled_reaction() 
+            ts = rxn.ts["forward"][0]
+            self.assertEquals(ts.symmetry_number, expected_symmetry) 
 
     def test_bounds_matrix(self):
 

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -1063,7 +1063,15 @@ class Conformer():
 
     def calculate_symmetry_number(self):
 
-        species = RMGSpecies().from_smiles(self.smiles)
-        self._symmetry_number = species.get_symmetry_number()
+        numbers = self.ase_molecule.numbers
+        positions = self.ase_molecule.positions
+
+        mol = RMGMolecule()
+        mol.from_xyz(numbers, positions)
+        try:
+            species = RMGSpecies(molecule=[mol])
+            self._symmetry_number = species.get_symmetry_number()
+        except ValueError:
+            self._symmetry_number = mol.get_symmetry_number() 
 
         return self._symmetry_number

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -1064,6 +1064,6 @@ class Conformer():
     def calculate_symmetry_number(self):
 
         species = RMGSpecies().from_smiles(self.smiles)
-        self.symmetry_number = species.get_symmetry_number()
+        self._symmetry_number = species.get_symmetry_number()
 
-        return self.symmetry_number
+        return self._symmetry_number

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -1062,28 +1062,8 @@ class Conformer():
         return self
 
     def calculate_symmetry_number(self):
-        from rmgpy.qm.symmetry import PointGroupCalculator
-        from rmgpy.qm.qmdata import QMData
 
-        atom_numbers = self.ase_molecule.get_atomic_numbers()
-        coordinates = self.ase_molecule.get_positions()
+        species = RMGSpecies().from_smiles(self.smiles)
+        self.symmetry_number = species.get_symmetry_number()
 
-        qmdata = QMData(
-            groundStateDegeneracy=1,  # Only needed to check if valid QMData
-            numberOfAtoms=len(atom_numbers),
-            atomicNumbers=atom_numbers,
-            atomCoords=(coordinates, str('angstrom')),
-            energy=(0.0, str('kcal/mol'))  # Only needed to avoid error
-        )
-        settings = type(str(''), (), dict(symmetryPath=str(
-            'symmetry'), scratchDirectory="."))()  # Creates anonymous class
-        pgc = PointGroupCalculator(settings, self.smiles, qmdata)
-        pg = pgc.calculate()
-        #os.remove("{}.symm".format(self.smiles))
-
-        if pg is not None:
-            symmetry_number = pg.symmetry_number
-        else:
-            symmetry_number = 1
-
-        return symmetry_number
+        return self.symmetry_number

--- a/autotst/speciesTest.py
+++ b/autotst/speciesTest.py
@@ -94,6 +94,10 @@ class TestConformer(unittest.TestCase):
         self.assertIsInstance(geometries[3],list)
         self.assertIsInstance(geometries[4],list)
     def test_calculate_symmetry_number(self):
+        species_to_test = {
+            "CC" : 18.0,
+            
+        }
         self.assertEquals(self.conformer.calculate_symmetry_number(), 18.0)
     def test_get_xyz_block(self):
         xyz_block = self.conformer.get_xyz_block()

--- a/autotst/speciesTest.py
+++ b/autotst/speciesTest.py
@@ -94,8 +94,7 @@ class TestConformer(unittest.TestCase):
         self.assertIsInstance(geometries[3],list)
         self.assertIsInstance(geometries[4],list)
     def test_calculate_symmetry_number(self):
-        self.assertTrue(self.conformer.calculate_symmetry_number() in [1,2])
-        os.remove("./CC.symm")
+        self.assertEquals(self.conformer.calculate_symmetry_number(), 18.0)
     def test_get_xyz_block(self):
         xyz_block = self.conformer.get_xyz_block()
         positions = self.conformer.ase_molecule.arrays["positions"]


### PR DESCRIPTION
Updated the way that AutoTST determines symmetry numbers. We were using the outdated `symmetry` package to calculate this but it was resulting in errors in determination of symmetry numbers (see #49). This PR updates the `autotst.species.Conformer.calculate_symmetry_number` method to use the symmetry number calculated by RMG's Species objects. Tests were updated accordingly as well.