### PR TITLE
Addressed a Typo in IRC validation

### DIFF
--- a/autotst/calculator/gaussian.py
+++ b/autotst/calculator/gaussian.py
@@ -539,11 +539,11 @@ class Gaussian():
             products = []
 
             for react in r.split("+"):
-                react = RMGMolecule(SMILES=react)
+                react = RMGMolecule(smiles=react)
                 reactants.append(react)
 
             for prod in p.split("+"):
-                prod = RMGMolecule(SMILES=prod)
+                prod = RMGMolecule(smiles=prod)
                 products.append(prod)
 
             possible_reactants = []


### PR DESCRIPTION
In RMG 2.4, creating a RMG molecule from smiles would look like this `Molecule(SMILES='smiles_string')`. However, when RMG was updated to python 3 the naming convention changed to `Molecule(smiles='smiles_string')`. This PR addresses this for validation of IRCs.