### PR TITLE
Incrementing radicals, specifically for excited [CH]

### DIFF
--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -308,8 +308,16 @@ class Reaction():
             # Generating lists of lists. Main list is the reactans or products
             # Secondary list is composed of the resonance structures for that species
             r, p = self.label.split("_") 
-            rmg_reactants = [rmgpy.molecule.Molecule(smiles=smile).generate_resonance_structures() for smile in r.split("+")]
-            rmg_products = [rmgpy.molecule.Molecule(smiles=smile).generate_resonance_structures() for smile in p.split("+")]
+
+            smiles_conversions = {
+                "[CH]":"[CH...]"
+            }
+            def get_rmg_mol(smile):
+                if smile.upper() in list(smiles_conversions.keys()):
+                    smile = smiles_conversions[smile.upper()]
+                return rmgpy.molecule.Molecule(smiles=smile).generate_resonance_structures()
+            rmg_reactants = [get_rmg_mol(smile) for smile in r.split("+")]
+            rmg_products = [get_rmg_mol(smile) for smile in p.split("+")]
 
             combos_to_try = list(itertools.product(
                 list(itertools.product(*rmg_reactants)),

--- a/autotst/reaction_test.py
+++ b/autotst/reaction_test.py
@@ -152,6 +152,25 @@ class TestReaction(unittest.TestCase):
         self.assertTrue(merged.get_labeled_atoms("*2")[0].is_hydrogen())
         self.assertTrue(merged.get_labeled_atoms("*1")[0].is_oxygen)
 
+    def test_labeled_reaction2(self):
+        """
+        Testing a reaction with the finicky [CH...] radical
+        """
+
+        reaction = Reaction("[CH2]+[H]_[H][H]+[CH]")
+        labeled_reaction, reaction_family = reaction.get_labeled_reaction()
+        self.assertEquals(reaction_family.lower(), "h_abstraction")
+
+        merged = labeled_reaction.reactants[0].merge(labeled_reaction.reactants[1])
+        self.assertTrue(merged.get_labeled_atoms("*1")[0].is_carbon())
+        self.assertTrue(merged.get_labeled_atoms("*2")[0].is_hydrogen())
+        self.assertTrue(merged.get_labeled_atoms("*3")[0].is_hydrogen())
+
+        merged = labeled_reaction.products[0].merge(labeled_reaction.products[1])
+        self.assertTrue(merged.get_labeled_atoms("*1")[0].is_hydrogen())
+        self.assertTrue(merged.get_labeled_atoms("*2")[0].is_hydrogen())
+        self.assertTrue(merged.get_labeled_atoms("*3")[0].is_carbon())
+
     def test_rmg_complexes(self):
         self.reaction.get_labeled_reaction()
         self.reaction.get_rmg_complexes()


### PR DESCRIPTION
There was an issue where when going from SMILES bases reaction strings to a labeled reaction when the reaction included `[CH]` radical as an abstractor in a hydrogen abstraction reaction. This issue stems from the fact that when one creates an RMG Molecule from the `[CH]` SMILES string, it creates the unexcited form of this molecule which wasn't able to participate in hydrogen abstraction reactions (e.g. `[CH2]+[H]_[H][H]+[CH]`). This PR corrects that case by replacing the `[CH]` SMILES with the excited SMILES string `[CH...]`. A test was added to cover these changes as well.