### PR TITLE
fix the typo in method opt_conf in systematic.py

### DIFF
--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -174,7 +174,7 @@ def systematic_search(conformer,
             label = conformer.smiles
             type = 'species'
 
-        if isinstance(calc, ase.calculators.calculator.FileIOCalculator):
+        if isinstance(calculator, ase.calculators.calculator.FileIOCalculator):
             if calculator.directory:
                 directory = calculator.directory 
             else: 


### PR DESCRIPTION
- Line 177 of `systematic.py` that is used to run systematic conformer search has a minor and this PR fixes it 