### PR TITLE
Addressed typos in Updating Methods for the TS Databases

### DIFF
--- a/autotst/data/base.py
+++ b/autotst/data/base.py
@@ -353,7 +353,7 @@ class TransitionStates(rmgpy.data.base.Database):
         if entry.short_desc.strip() != '':
             f.write('    short_desc = u"""')
             try:
-                f.write(entry.short_desc.encode('utf-8'))
+                f.write(entry.short_desc)
             except:
                 f.write(entry.short_desc.strip().encode(
                     'ascii', 'ignore') + "\n")
@@ -363,7 +363,7 @@ class TransitionStates(rmgpy.data.base.Database):
             f.write('    long_desc = \n')
             f.write('u"""\n')
             try:
-                f.write(entry.long_desc.strip().encode('utf-8') + "\n")
+                f.write(entry.long_desc.strip() + "\n")
             except:
                 f.write(entry.long_desc.strip().encode(
                     'ascii', 'ignore') + "\n")
@@ -566,7 +566,7 @@ class TransitionStateDepository(rmgpy.data.base.Database):
         if entry.short_desc.strip() != '':
             f.write('    short_desc = u"""')
             try:
-                f.write(entry.short_desc.encode('utf-8'))
+                f.write(entry.short_desc)
             except:
                 f.write(entry.short_desc.strip().encode(
                     'ascii', 'ignore') + "\n")
@@ -576,7 +576,7 @@ class TransitionStateDepository(rmgpy.data.base.Database):
             f.write('    long_desc = \n')
             f.write('u"""\n')
             try:
-                f.write(entry.long_desc.strip().encode('utf-8') + "\n")
+                f.write(entry.long_desc.strip() + "\n")
             except:
                 f.write(entry.long_desc.strip().encode(
                     'ascii', 'ignore') + "\n")

--- a/autotst/data/update.py
+++ b/autotst/data/update.py
@@ -761,7 +761,7 @@ class DatabaseUpdater:
                     if isinstance(group, str):
                         assert False, "Discrepancy between versions of RMG_Database and this one"
 
-                    self.group_cmments[group].add('{0!s}'.format(template))
+                    self.group_comments[group].add('{0!s}'.format(template))
 
         self.A = np.array(A)
         self.b = np.array(b)
@@ -883,6 +883,6 @@ class DatabaseUpdater:
         elif path is None:
             path = os.path.join(self.path, 'TS_groups.py')
 
-        self.database.saveTransitionStateGroups(path)
+        self.database.save_transition_state_groups(path)
         logging.info('Saved {} Database to: {}'.format(self.family, path))
         return

--- a/autotst/data/update.py
+++ b/autotst/data/update.py
@@ -67,10 +67,8 @@ def get_unknown_species(reactions, known_species):
 
     for i, reaction in enumerate(reactions):
         rmg_reaction = reaction.rmg_reaction
-        r1, r2 = rmg_reaction.reactants
-        p1, p2 = rmg_reaction.products
 
-        relavent_species = [r1, r2, p1, p2]
+        relavent_species = rmg_reaction.reactants + rmg_reaction.products
         relavent_labels = {}
 
         for rel_species in relavent_species:
@@ -285,10 +283,8 @@ def update_known_reactions(
         distance_data = DistanceData(distances=Distances, method=method)
 
         rmg_reaction = reaction.rmg_reaction
-        r1, r2 = rmg_reaction.reactants
-        p1, p2 = rmg_reaction.products
 
-        relavent_species = [r1, r2, p1, p2]
+        relavent_species = rmg_reaction.reactants + rmg_reaction.products
         relavent_labels = {}
 
         for rel_species in relavent_species:
@@ -302,12 +298,19 @@ def update_known_reactions(
                 logging.warning(
                     '{} not found in species dictionary'.format(rel_species))
 
-        lr1 = found_species[r1]
-        lr2 = found_species[r2]
-        lp1 = found_species[p1]
-        lp2 = found_species[p2]
 
-        Label = '{} + {} <=> {} + {}'.format(lr1, lr2, lp1, lp2)
+        labeled_reactants = [found_species[reactant] for reactant in rmg_reaction.reactants]
+        labeled_products = [found_species[product] for product in rmg_reaction.products]
+        if len(labeled_reactants) == 2:
+            left_string = "{} + {}".format(labeled_reactants[0], labeled_reactants[1])
+        else:
+            left_string = "{}".format(labeled_reactants[0])
+        if len(labeled_products) == 2:
+            right_string = "{} + {}".format(labeled_products[0], labeled_products[1])
+        else:
+            right_string = "{}".format(labeled_products[0])
+
+        Label = '{} <=> {}'.format(left_string, right_string)
         #print Label
 
         # adding new entries to r_db, r_db will contain old and new reactions
@@ -383,10 +386,11 @@ def update_databases(reactions, method='', short_desc='', reaction_family='', ov
         reactions, list), 'Provide auto-TST reaction object[s]'
     assert len(reactions) > 0
 
-    if reaction_family == '':
-        reaction_family = 'H_Abstraction'
-        logging.warning(
-            'Defaulting to reaction family of {}'.format(reaction_family))
+    # Not a good assumption, @nateharms' opinion
+    #if reaction_family == '':
+    #    reaction_family = 'H_Abstraction'
+    #    logging.warning(
+    #        'Defaulting to reaction family of {}'.format(reaction_family))
 
     general_path = os.path.join(os.path.expandvars(
         '$AUTOTST'), 'database', reaction_family, 'TS_training')

--- a/autotst/data/update.py
+++ b/autotst/data/update.py
@@ -479,9 +479,10 @@ def TS_Database_Update(families, path=None, auto_save=False):
             families.remove(family)
 
     logging.info("Loading RMG Database...")
-    rmg_database = RMGDatabase()
-    database_path = os.path.join(os.path.expandvars(
-        '$RMGpy'), "..", 'RMG-database', 'input')
+    import rmgpy
+    import rmgpy.data.rmg
+    rmg_database = rmgpy.data.rmg.RMGDatabase()
+    database_path = rmgpy.settings['database.directory']
 
     try:
         rmg_database.load(database_path,

--- a/autotst/data/update_test.py
+++ b/autotst/data/update_test.py
@@ -30,12 +30,14 @@
 
 import unittest, os, sys, shutil
 from ..reaction import Reaction
-#import .update as UpdateMethods
+from .update import get_unknown_species
+
 
 class TestUpdateMethods(unittest.TestCase):
 
     def setUp(self):
         self.reaction = Reaction("CC+[O]O_[CH2]C+OO")
+        self.reaction.get_labeled_reaction()
         self.family = "H_Abstraction"
         self.method = "m062x/cc-pVTZ"
         self.short_description = "test case"
@@ -43,6 +45,11 @@ class TestUpdateMethods(unittest.TestCase):
     def test_update(self):
         UpdateMethods.update_al(self.reaction, self.family, method=self.method, short_desc=self.short_description)
         self.assertTrue(True)"""
+
+    def test_get_unknown_species(self):
+        "A test designed to count the number of unknown species"
+        unknowns = get_unknown_species([self.reaction], [])
+        self.assertEqual(len(unknowns), 4)
 
         
 if __name__ == "__main__":


### PR DESCRIPTION
There were some typos and py2->py3 issues that crept up when I was trying to use previous updating methods to update the TS database with new TS training data. This PR addresses makes these fixes. Two more PRs will exist that will (1) provide an example script that can update the database automatically and (2) provide an updated database with new AutoTST numbers.