### PR TITLE
Converted "".format() to f-string literals

### DIFF
--- a/autotst/calculator/gaussian.py
+++ b/autotst/calculator/gaussian.py
@@ -84,7 +84,7 @@ class Gaussian():
         self.settings = settings
         self.convergence = convergence
         convergence_options = ["", "verytight", "tight", "loose"]
-        assert self.convergence.lower() in convergence_options,"{} is not among the supported convergence options {}".format(self.convergence,convergence_options)
+        assert self.convergence.lower() in convergence_options,f"{self.convergence} is not among the supported convergence options {convergence_options}"
         self.directory = directory
 
         try: 
@@ -100,9 +100,9 @@ class Gaussian():
 
     def __repr__(self):
         if isinstance(self.conformer, TS):
-            return '<Gaussian Calculator {}>'.format(self.conformer.reaction_label)
+            return f'<Gaussian Calculator {self.conformer.reaction_label}>'
         elif isinstance(self.conformer, Conformer):
-            return '<Gaussian Calculator {}>'.format(self.conformer.smiles)
+            return f'<Gaussian Calculator {self.conformer.smiles}>'
         else:
             return '<Gaussian Calculator>'
 
@@ -135,7 +135,7 @@ class Gaussian():
         addsec = ""
         for bond in self.conformer.bonds:
             i, j = bond.atom_indices
-            addsec += "B {} {}\n".format(i + 1, j + 1)
+            addsec += f"B {(i + 1)} {(j + 1)}\n"
 
         i, j, k, l = torsion.atom_indices
         addsec += "D {} {} {} {} S {} {}\n".format(
@@ -144,18 +144,18 @@ class Gaussian():
         if isinstance(self.conformer, TS):
             extra = "Opt=(ts,CalcFC,ModRedun)"
             label = conformer_dir = self.conformer.reaction_label
-            label += "_{}by{}_{}_{}".format(steps, int(step_size), j, k)
+            label += f"_{steps}by{int(step_size)}_{j}_{k}"
             conformer_type = "ts"
         elif isinstance(self.conformer, Conformer):
             label = conformer_dir = self.conformer.smiles
-            label += "_{}by{}_{}_{}".format(steps, int(step_size), j, k)
+            label += f"_{steps}by{int(step_size)}_{j}_{k}"
             conformer_type = "species"
             extra = "Opt=(CalcFC,ModRedun)"
 
         for locked_torsion in self.conformer.torsions:  # TODO: maybe doesn't work;
             if sorted(locked_torsion.atom_indices) != sorted(torsion.atom_indices):
                 a, b, c, d = locked_torsion.atom_indices
-                addsec += 'D {0} {1} {2} {3} F\n'.format(a+1, b+1, c+1, d+1)
+                addsec += f'D {(a + 1)} {(b + 1)} {(c + 1)} {(d + 1)} F\n'
 
         self.conformer.rmg_molecule.update_multiplicity()
         mult = self.conformer.rmg_molecule.multiplicity
@@ -208,7 +208,7 @@ class Gaussian():
 
         self.conformer.rmg_molecule.update_multiplicity()
 
-        label = "{}_{}".format(self.conformer.smiles, self.conformer.index)
+        label = f"{self.conformer.smiles}_{self.conformer.index}"
 
         new_scratch = os.path.join(
             self.directory,
@@ -229,7 +229,7 @@ class Gaussian():
             scratch=new_scratch,
             method=self.settings["method"],
             basis=self.settings["basis"],
-            extra="opt=(calcfc,maxcycles=900,{}) freq IOP(7/33=1,2/16=3) scf=(maxcycle=900)".format(self.convergence),
+            extra=f"opt=(calcfc,maxcycles=900,{self.convergence}) freq IOP(7/33=1,2/16=3) scf=(maxcycle=900)",
             multiplicity=self.conformer.rmg_molecule.multiplicity)
         ase_gaussian.atoms = self.conformer.ase_molecule
         del ase_gaussian.parameters['force']
@@ -273,13 +273,13 @@ class Gaussian():
             ind2 = self.conformer.rmg_molecule.get_labeled_atoms("*2")[0].sorting_label
             ind3 = self.conformer.rmg_molecule.get_labeled_atoms("*3")[0].sorting_label
         else:
-            logging.error("Reaction family {} is not supported...".format(self.conformer.reaction_family))
+            logging.error(f"Reaction family {self.conformer.reaction_family} is not supported...")
             raise AssertionError
 
         combos = ""
-        combos += "{0} {1} F\n".format(ind1+1, ind2+1)
-        combos += "{0} {1} F\n".format(ind2+1, ind3+1)
-        combos += "{0} {1} {2} F".format(ind1+1, ind2+1, ind3+1)
+        combos += f"{(ind1 + 1)} {(ind2 + 1)} F\n"
+        combos += f"{(ind2 + 1)} {(ind3 + 1)} F\n"
+        combos += f"{(ind1 + 1)} {(ind2 + 1)} {(ind3 + 1)} F"
 
         ase_gaussian = ase.calculators.gaussian.Gaussian(
             mem=self.settings["mem"],
@@ -323,7 +323,7 @@ class Gaussian():
         addsec = ""
         for combo in list(itertools.combinations(indicies, 2)):
             a, b = combo
-            addsec += "{0} {1} F\n".format(a + 1, b + 1)
+            addsec += f"{(a + 1)} {(b + 1)} F\n"
 
         self.conformer.rmg_molecule.update_multiplicity()
 
@@ -576,5 +576,5 @@ class Gaussian():
                     if target_reaction.is_isomorphic(test_reaction):
                         logging.info("IRC calculation was successful!")
                         return True
-            logging.info("IRC calculation failed for {} :(".format(irc_path))
+            logging.info(f"IRC calculation failed for {irc_path} :(")
             return False

--- a/autotst/calculator/orca.py
+++ b/autotst/calculator/orca.py
@@ -158,13 +158,13 @@ class Orca():
 
         # Write FOD input
         with open(outfile, 'w+') as f:
-            f.write('# FOD anaylsis for {} \n'.format(self.label))
+            f.write(f'# FOD anaylsis for {self.label} \n')
             f.write('! FOD \n')
             f.write('\n')
-            f.write('%pal nprocs {} end \n'.format(str(self.nprocs)))
+            f.write(f'%pal nprocs {str(self.nprocs)} end \n')
             f.write('%scf\n  MaxIter  600\nend\n')
-            f.write('%base "{}_fod" \n'.format(self.base))
-            f.write('*xyz {} {}\n'.format(self.charge, self.mult))
+            f.write(f'%base "{self.base}_fod" \n')
+            f.write(f'*xyz {self.charge} {self.mult}\n')
             f.write(self.coords)
             f.write('*\n')
 
@@ -173,7 +173,7 @@ class Orca():
         checks if an Orca job terminated normally.
         Returns True is normal termination and False if something went wrong.
         """
-        assert os.path.exists(path), 'It seems {} is not a valid path'.format(path)
+        assert os.path.exists(path), f'It seems {path} is not a valid path'
 
         lines = open(path,'r').readlines()[-5:]
         complete = False
@@ -188,7 +188,7 @@ class Orca():
         Reads an FOD log to get the FOD number.
         Returns FOD number if log terminated normally and FOD number can be found.
         """
-        assert os.path.exists(path),'It seems {} is not a valid path'.format(path)
+        assert os.path.exists(path),f'It seems {path} is not a valid path'
 
         if self.check_normal_termination(path):
             N_FOD = None
@@ -197,10 +197,10 @@ class Orca():
                     N_FOD = float(line.split(" ")[-1])
                     break
             if N_FOD:
-                logging.info("the FOD number is {}".format(N_FOD))
+                logging.info(f"the FOD number is {N_FOD}")
                 return N_FOD
             else:
-                logging.info("It appears that the orca terminated normally for {}, but we couldn't find the FOD number".format(path))
+                logging.info(f"It appears that the orca terminated normally for {path}, but we couldn't find the FOD number")
         else:
-            logging.info('It appears the orca FOD job for {} did not terminate normally'.format(path))
+            logging.info(f'It appears the orca FOD job for {path} did not terminate normally')
             

--- a/autotst/calculator/statmech.py
+++ b/autotst/calculator/statmech.py
@@ -176,11 +176,11 @@ class StatMech():
         for smiles, confs in list(species.conformers.items()):
             if os.path.exists(os.path.join(self.directory, "species", smiles, smiles + ".log")):
                 logging.info(
-                    "Lowest energy conformer log file exists for {}".format(smiles))
+                    f"Lowest energy conformer log file exists for {smiles}")
                 self.write_conformer_file(conformer=confs[0])
             else:
                 logging.info(
-                    "Lowest energy conformer log file DOES NOT exist for {}".format(smiles))
+                    f"Lowest energy conformer log file DOES NOT exist for {smiles}")
 
     def write_conformer_file(self, conformer):
         """
@@ -229,14 +229,14 @@ class StatMech():
         atom_dict = self.get_atoms(conformer=conformer)  # Fix this
 
         for atom, count in atom_dict.items():
-            output.append("    '{0}': {1},".format(atom, count))
+            output.append(f"    '{atom}': {count},")
         output = output + ['}', '']
 
         bond_dict = self.get_bonds(conformer=conformer) 
         if bond_dict != {}:
             output.append('bonds = {')
             for bond_type, num in bond_dict.items():
-                output.append("    '{0}': {1},".format(bond_type, num))
+                output.append(f"    '{bond_type}': {num},")
             output.append("}")
         else:
             output.append('bonds = {}')
@@ -244,22 +244,21 @@ class StatMech():
         external_symmetry = conformer.calculate_symmetry_number()
 
         output += ["",
-                   "linear = {}".format(conformer.rmg_molecule.is_linear()),
+                   f"linear = {conformer.rmg_molecule.is_linear()}",
                    "",
-                   "externalSymmetry = {}".format(external_symmetry),
+                   f"externalSymmetry = {external_symmetry}",
                    "",
-                   "spinMultiplicity = {}".format(conformer.rmg_molecule.multiplicity),
+                   f"spinMultiplicity = {conformer.rmg_molecule.multiplicity}",
                    "",
                    "opticalIsomers = 1",
                    ""]
 
-        output += ["energy = {", "    '{0}': Log('{1}.log'),".format(
-            self.model_chemistry, label), "}", ""]  # fix this
+        output += ["energy = {", f"    '{self.model_chemistry}': Log('{label}.log'),", "}", ""]  # fix this
 
-        output += ["geometry = Log('{0}.log')".format(label), ""]
+        output += [f"geometry = Log('{label}.log')", ""]
 
         output += [
-            "frequencies = Log('{0}.log')".format(label), ""]
+            f"frequencies = Log('{label}.log')", ""]
 
         """
         TODO: add rotor information @carl
@@ -306,7 +305,7 @@ class StatMech():
                 "ts",
                 conformer.reaction_label,
                 "torsions",
-                comformer.reaction_label + "_36by10_{0}_{1}.log".format(j, k)
+                comformer.reaction_label + f"_36by10_{j}_{k}.log"
             )
         else:
             tor_log = os.path.join(
@@ -314,12 +313,12 @@ class StatMech():
                 "species",
                 conformer.smiles,
                 "torsions",
-                conformer.smiles + '_36by10_{0}_{1}.log'.format(j, k)
+                conformer.smiles + f'_36by10_{j}_{k}.log'
             )
 
         if not os.path.exists(tor_log):
             logging.info(
-                "Torsion log file does not exist for {}".format(torsion))
+                f"Torsion log file does not exist for {torsion}")
             return ""
 
         top_IDs = []
@@ -330,8 +329,7 @@ class StatMech():
         # Adjusted to start from 1 instead of 0
         top_IDs_adj = [ID+1 for ID in top_IDs]
 
-        info = "     HinderedRotor(scanLog=Log('{0}'), pivots={1}, top={2}, fit='fourier'),".format(
-            tor_log, tor_center_adj, top_IDs_adj)
+        info = f"     HinderedRotor(scanLog=Log('{tor_log}'), pivots={tor_center_adj}, top={top_IDs_adj}, fit='fourier'),"
 
         return info
 
@@ -380,14 +378,14 @@ class StatMech():
         atom_dict = self.get_atoms(conformer=transitionstate)  # need to fix
 
         for atom, count in atom_dict.items():
-            output.append("    '{0}': {1},".format(atom, count))
+            output.append(f"    '{atom}': {count},")
         output = output + ['}', '']
 
         bond_dict = self.get_bonds(conformer=transitionstate)  # need to fix
         if bond_dict != {}:
             output.append('bonds = {')
             for bond_type, num in bond_dict.items():
-                output.append("    '{0}': {1},".format(bond_type, num))
+                output.append(f"    '{bond_type}': {num},")
 
             output.append("}")
         else:
@@ -399,21 +397,19 @@ class StatMech():
         output += ["",
                    "linear = False",
                    "",
-                   "externalSymmetry = {}".format(external_symmetry),
+                   f"externalSymmetry = {external_symmetry}",
                    "",
-                   "spinMultiplicity = {}".format(
-                       transitionstate.rmg_molecule.multiplicity),
+                   f"spinMultiplicity = {transitionstate.rmg_molecule.multiplicity}",
                    "",
                    "opticalIsomers = 1",
                    ""]
 
-        output += ["energy = {", "    '{0}': Log('{1}.log'),".format(
-            self.model_chemistry, label), "}", ""]  # fix this
+        output += ["energy = {", f"    '{self.model_chemistry}': Log('{label}.log'),", "}", ""]  # fix this
 
-        output += ["geometry = Log('{0}.log')".format(label), ""]
+        output += [f"geometry = Log('{label}.log')", ""]
 
         output += [
-            "frequencies = Log('{0}.log')".format(label), ""]
+            f"frequencies = Log('{label}.log')", ""]
 
         output += ["rotors = []", ""]  # TODO: Fix this
 
@@ -442,10 +438,8 @@ class StatMech():
             "#!/usr/bin/env python",
             "# -*- coding: utf-8 -*-",
             "",
-            'modelChemistry = "{0}"'.format(
-                self.model_chemistry),  # fix this
-            "frequencyScaleFactor = {0}".format(
-                self.freq_scale_factor),  # fix this
+            f'modelChemistry = "{self.model_chemistry}"',  # fix this
+            f"frequencyScaleFactor = {self.freq_scale_factor}",  # fix this
             "useHinderedRotors = False",  # fix this @carl
             "useBondCorrections = False",
             ""]
@@ -463,7 +457,7 @@ class StatMech():
                                         smiles, smiles + ".log")
                     if not os.path.exists(path):
                         logging.info(
-                            "It looks like {} doesn't have any optimized geometries".format(smiles))
+                            f"It looks like {smiles} doesn't have any optimized geometries")
                         continue
 
                     parser = cclib.io.ccread(path, loglevel=logging.ERROR)
@@ -478,7 +472,7 @@ class StatMech():
                                     smiles, smiles + ".log")
                 if not os.path.exists(path):
                     logging.info(
-                        "It looks like {} doesn't have any optimized geometries".format(smiles))
+                        f"It looks like {smiles} doesn't have any optimized geometries")
                     continue
 
                 parser = cclib.io.ccread(path, loglevel=logging.ERROR)
@@ -486,14 +480,14 @@ class StatMech():
                 lowest_energy_conf = list(react.conformers.values())[0][0]
 
             # r_smiles.append(lowest_energy_conf.smiles)
-            r_smiles.append("react_{}".format(i))
+            r_smiles.append(f"react_{i}")
             label = lowest_energy_conf.smiles
             if label in labels:
                 continue
             else:
                 labels.append(label)
-            line = "species('{0}', '{1}', structure=SMILES('{2}'))".format(
-                "react_{}".format(i), os.path.join(self.directory, "species", label, label + ".py"), label)
+            p = os.path.join(self.directory, "species", label, label + ".py")
+            line = f"species('react_{i}', '{p}', structure=SMILES('{label}'))"
             top.append(line)
 
         for i, prod in enumerate(self.reaction.products):
@@ -507,7 +501,7 @@ class StatMech():
                                         smiles, smiles + ".log")
                     if not os.path.exists(path):
                         logging.info(
-                            "It looks like {} doesn't have any optimized geometries".format(smiles))
+                            f"It looks like {smiles} doesn't have any optimized geometries")
                         continue
 
                     parser = cclib.io.ccread(path, loglevel=logging.ERROR)
@@ -522,7 +516,7 @@ class StatMech():
                                     smiles, smiles + ".log")
                 if not os.path.exists(path):
                     logging.info(
-                        "It looks like {} doesn't have any optimized geometries".format(smiles))
+                        f"It looks like {smiles} doesn't have any optimized geometries")
                     continue
 
                 parser = cclib.io.ccread(path, loglevel=logging.ERROR)
@@ -530,33 +524,30 @@ class StatMech():
                 lowest_energy_conf = list(prod.conformers.values())[0][0]
 
             # p_smiles.append(lowest_energy_conf.smiles)
-            p_smiles.append("prod_{}".format(i))
+            p_smiles.append(f"prod_{i}")
             label = lowest_energy_conf.smiles
             if label in labels:
                 continue
             else:
                 labels.append(label)
-            line = "species('{0}', '{1}', structure=SMILES('{2}'))".format(
-                "prod_{}".format(i), os.path.join(self.directory, "species", label, label + ".py"), label)
+            p = os.path.join(self.directory, "species", label, label + ".py")
+            line = f"species('prod_{i}', '{p}', structure=SMILES('{label}'))"
             top.append(line)
-
-        line = "transitionState('TS', '{0}')".format(os.path.join(
-            self.directory, "ts", self.reaction.label, self.reaction.label + ".py"))
+        p = os.path.join(self.directory, "ts", self.reaction.label, self.reaction.label + ".py")
+        line = f"transitionState('TS', '{p}')"
         top.append(line)
 
         line = ["",
                 "reaction(",
-                "    label = '{0}',".format(self.reaction.label),
-                "    reactants = {},".format(
-                    r_smiles),
-                "    products = {},".format(
-                    p_smiles),
+                f"    label = '{self.reaction.label}',",
+                f"    reactants = {r_smiles},",
+                f"    products = {p_smiles},",
                 "    transitionState = 'TS',",
                 "    tunneling = 'Eckart',",
                 ")",
                 "",
                 "statmech('TS')",
-                "kinetics('{0}')".format(self.reaction.label)]
+                f"kinetics('{self.reaction.label}')"]
 
         top += line
 
@@ -587,16 +578,13 @@ class StatMech():
             "#!/usr/bin/env python",
             "# -*- coding: utf-8 -*-",
             "",
-            'modelChemistry = "{0}"'.format(
-                model_chemistry),  # fix this
-            "frequencyScaleFactor = {0}".format(
-                freq_scale_factor),  # fix this
+            f'modelChemistry = "{model_chemistry}"',  # fix this
+            f"frequencyScaleFactor = {freq_scale_factor}",  # fix this
             "useHinderedRotors = False",  # fix this @carl
             "useBondCorrections = False",
             ""]
-
-        line = "species('species', '{1}', structure=SMILES('{2}'))".format(
-            "species", os.path.join(conformer.smiles + ".py"), conformer.smiles)
+        p = os.path.join(conformer.smiles + ".py")
+        line = f"species('species', '{f}', structure=SMILES('{conformer.smiles}'))"
         top.append(line)
 
         top.append("statmech('species')")

--- a/autotst/calculator/vibrational_analysis.py
+++ b/autotst/calculator/vibrational_analysis.py
@@ -69,8 +69,7 @@ class VibrationalAnalysis():
             label = None
         else:
             label = self.ts.reaction_label
-        return '<Vibrational Analysis "{0}">'.format(
-            label)
+        return f'<Vibrational Analysis "{label}">'
 
     def get_log_file(self):
         """
@@ -88,7 +87,7 @@ class VibrationalAnalysis():
             "ts",
             self.ts.reaction_label,
             "conformers",
-            "{}_{}_{}.log".format(self.ts.reaction_label, self.ts.direction, self.ts.index))
+            f"{self.ts.reaction_label}_{self.ts.direction}_{self.ts.index}.log")
         return self.log_file
 
     def parse_vibrations(self):

--- a/autotst/calculator/vibrational_analysis_test.py
+++ b/autotst/calculator/vibrational_analysis_test.py
@@ -69,7 +69,7 @@ class VibrationalAnalysisTest(unittest.TestCase):
             "ts",
             self.ts.reaction_label,
             "conformers",
-            "{}_{}_{}.log".format(self.ts.reaction_label, self.ts.direction, self.ts.index)
+            f"{self.ts.reaction_label}_{self.ts.direction}_{self.ts.index}.log"
         )
 
         self.assertEqual(log_file, actual_path)

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -132,13 +132,13 @@ def opt_conf(i):
                 directory = calculator.directory 
             else: 
                 directory = 'conformer_logs'
-            calculator.label = "{}_{}".format(conformer.smiles, conformer.index)
-            calculator.directory = os.path.join(directory, label,'{}_{}'.format(conformer.smiles, conformer.index))
+            calculator.label = f"{conformer.smiles}_{conformer.index}"
+            calculator.directory = os.path.join(directory, label,f'{conformer.smiles}_{conformer.index}')
             if not os.path.exists(calculator.directory):
                 try:
                     os.makedirs(calculator.directory)
                 except OSError:
-                    logging.info("An error occured when creating {}".format(calculator.directory))
+                    logging.info(f"An error occured when creating {calculator.directory}")
 
             calculator.atoms = conformer.ase_molecule
 
@@ -163,7 +163,7 @@ def opt_conf(i):
                         conformer.ase_molecule.arrays["positions"]
                     )
                     if not rmg_mol.is_isomorphic(reference_mol):
-                        logging.info("{}_{} is not isomorphic with reference mol".format(conformer,str(conformer.index)))
+                        logging.info(f"{conformer}_{str(conformer.index)} is not isomorphic with reference mol")
                         return False
                 except rmgpy.exceptions.AtomTypeError:
                     logging.info("Could not create a RMG Molecule from optimized conformer coordinates...assuming not isomorphic")
@@ -259,7 +259,7 @@ def systematic_search(conformer,
     global conformers
     conformers = {}
     combinations = {}
-    logging.info("There are {} possible conformers to investigate...".format(len(combos)))
+    logging.info(f"There are {len(combos)} possible conformers to investigate...")
     for index, combo in enumerate(combos):
 
         combinations[index] = combo
@@ -351,7 +351,6 @@ def systematic_search(conformer,
             confs.append(conf)
             i += 1
 
-    logging.info("We have identified {} unique, low-energy conformers for {}".format(
-        len(confs), conformer))
+    logging.info(f"We have identified {len(confs)} unique, low-energy conformers for {conformer}")
     
     return confs

--- a/autotst/data/base.py
+++ b/autotst/data/base.py
@@ -88,12 +88,11 @@ class QMData():
         object.
         """
         string = 'QMData('
-        string += "ground_state_degeneracy={0!r}, ".format(
-            self.ground_state_degeneracy)
-        string += "number_of_atoms={0!r}, ".format(self.number_of_atoms)
-        string += "steric_energy={0!r}, ".format(self.steric_energy)
-        string += "molecular_mass={0!r}, ".format(self.molecular_mass)
-        string += "energy={0!r}, ".format(self.energy)
+        string += f"ground_state_degeneracy={self.ground_state_degeneracy!r}, "
+        string += f"number_of_atoms={self.number_of_atoms!r}, "
+        string += f"steric_energy={self.steric_energy!r}, "
+        string += f"molecular_mass={self.molecular_mass!r}, "
+        string += f"energy={self.energy!r}, "
         string += "atomic_numbers={0}, ".format(
             "{0!r}".format(self.atomic_numbers).replace(" ", ""))
         string += "rotational_constants={0}, ".format("{0}".format(
@@ -102,7 +101,7 @@ class QMData():
             self.atom_coords).replace("\n", "").replace(" ", ""))
         string += "frequencies={0}, ".format("{0}".format(
             self.frequencies).replace("\n", "").replace(" ", ""))
-        string += "source={0!r}, ".format(self.source)
+        string += f"source={self.source!r}, "
         string = string[:-2] + ')'
         return string
 
@@ -144,20 +143,19 @@ class DistanceData():
 
         strings.append("distances={")
         for key in sorted(self.distances.keys()):
-            strings.append("{0!r}: {1:.6f},".format(key, self.distances[key]))
+            strings.append(f"{key!r}: {self.distances[key]:.6f},")
         strings.append("}")
 
         if self.uncertainties is not None:
             strings.append(", uncertainties={")
             for key in sorted(self.uncertainties.keys()):
-                strings.append("{0!r}: {1:.6f},".format(
-                    key, self.uncertainties[key]))
+                strings.append(f"{key!r}: {self.uncertainties[key]:.6f},")
             strings.append("}")
 
         if self.method:
-            strings.append(", method={0!r}".format(self.method))
+            strings.append(f", method={self.method!r}")
         if self.comment:
-            strings.append(", comment={0!r}".format(self.comment))
+            strings.append(f", comment={self.comment!r}")
         strings.append(")")
         return ''.join(strings)
 
@@ -165,8 +163,7 @@ class DistanceData():
         """Adds the `other` distances to these."""
         assert len(
             self.distances) == len(
-            other.distances), "self and other must have the same size dictionary of distances, but self={0!r} and other={1!r}".format(
-            self, other)
+            other.distances), f"self and other must have the same size dictionary of distances, but self={self} and other={other}"
         for key, value in other.distances.items():
             self.distances[key] += value
         if self.uncertainties and other.uncertainties:
@@ -203,18 +200,18 @@ class TransitionStates(rmgpy.data.base.Database):
         fpath = os.path.join(path, 'TS_training', 'reactions.py')
 
         logging.debug(
-            "Loading transitions state family training set from {0}".format(fpath))
+            f"Loading transitions state family training set from {fpath}")
 
         depository = TransitionStateDepository(
-            label='{0}/TS_training'.format(path.split('/')[-1]))  # 'intra_H_migration/TS_training')
+            label=f"{path.split('/')[-1]}/TS_training")  # 'intra_H_migration/TS_training')
         depository.load(fpath, local_context, global_context)
         self.depository = depository
 
         fpath = os.path.join(path, 'TS_groups.py')
         logging.info(
-            "Loading transitions state family groups from {0}".format(fpath))
+            f"Loading transitions state family groups from {fpath}")
         # 'intra_H_migration/TS_groups')
-        groups = TSGroups(label='{0}/TS_groups'.format(path.split('/')[-1]))
+        groups = TSGroups(label=f"{path.split('/')[-1]}/TS_groups")
         groups.load(fpath, local_context, global_context)
 
         self.family.forward_template.reactants = [
@@ -245,8 +242,8 @@ class TransitionStates(rmgpy.data.base.Database):
         f = codecs.open(path, 'w', 'utf-8')
         f.write('#!/usr/bin/env python\n')
         f.write('# encoding: utf-8\n\n')
-        f.write('name = "{0}"\n'.format(self.groups.name))
-        f.write('short_desc = u"{0}"\n'.format(self.groups.short_desc))
+        f.write(f'name = "{self.groups.name}\"\n')
+        f.write(f'short_desc = u"{self.groups.short_desc}\"\n')
         f.write('long_desc = u"""\n')
         f.write(self.groups.long_desc)
         f.write('\n"""\n\n')
@@ -288,9 +285,9 @@ class TransitionStates(rmgpy.data.base.Database):
             return [(key, efficiencies[key]) for key in keys]
 
         f.write('entry(\n')
-        f.write('    index = {0:d},\n'.format(entry.index))
+        f.write(f'    index = {entry.index:d},\n')
         if entry.label != '':
-            f.write('    label = "{0}",\n'.format(entry.label))
+            f.write(f'    label = "{entry.label}",\n')
 
         # Entries for kinetic rules, libraries, training reactions
         # and depositories will have a rmgpy.reaction.Reaction object for its item
@@ -299,23 +296,17 @@ class TransitionStates(rmgpy.data.base.Database):
             # kinetic rules would have a Group object for its reactants instead of Species
             if isinstance(entry.item.reactants[0], rmgpy.species.Species):
                 # Add degeneracy if the reaction is coming from a depository or kinetics library
-                f.write('    degeneracy = {0:.1f},\n'.format(
-                    entry.item.degeneracy))
+                f.write(f'    degeneracy = {entry.item.degeneracy:.1f},\n')
                 if entry.item.duplicate:
-                    f.write('    duplicate = {0!r},\n'.format(
-                        entry.item.duplicate))
+                    f.write(f'    duplicate = {entry.item.duplicate!r},\n')
                 if not entry.item.reversible:
-                    f.write('    reversible = {0!r},\n'.format(
-                        entry.item.reversible))
+                    f.write(f'    reversible = {entry.item.reversible!r},\n')
                 if entry.item.allow_pdep_route:
-                    f.write('    allow_pdep_route = {0!r},\n'.format(
-                        entry.item.allow_pdep_route))
+                    f.write(f'    allow_pdep_route = {entry.item.allow_pdep_route},\n')
                 if entry.item.elementary_high_p:
-                    f.write('    elementary_high_p = {0!r},\n'.format(
-                        entry.item.elementary_high_p))
+                    f.write(f'    elementary_high_p = {entry.item.elementary_high_p!r},\n')
                 if entry.item.allow_max_rate_violation:
-                    f.write('    allow_max_rate_violation = {0!r},\n'.format(
-                        entry.item.allow_max_rate_violation))
+                    f.write(f'    allow_max_rate_violation = {entry.item.allow_max_rate_violation!r},\n')
             # Entries for groups with have a group or logicNode for its item
         elif isinstance(entry.item, rmgpy.molecule.Group):
             f.write('    group = \n')
@@ -323,16 +314,16 @@ class TransitionStates(rmgpy.data.base.Database):
             f.write(entry.item.to_adjacency_list())
             f.write('""",\n')
         elif isinstance(entry.item, rmgpy.data.base.LogicNode):
-            f.write('    group = "{0}",\n'.format(entry.item))
+            f.write(f'    group = "{entry.item}",\n')
         else:
             raise rmgpy.data.base.DatabaseError(
-                "Encountered unexpected item of type {0} while saving database.".format(entry.item.__class__))
+                f"Encountered unexpected item of type {entry.item.__class__} while saving database.")
 
         # Write distances
         if isinstance(entry.data, DistanceData):
             data_str = arkane.output.prettify(repr(entry.data))
             data_str = data_str.replace('\n', '\n    ')
-            f.write('    distances = {},\n'.format(data_str))
+            f.write(f'    distances = {data_str},\n')
         else:
             assert False
 
@@ -340,15 +331,15 @@ class TransitionStates(rmgpy.data.base.Database):
         if entry.reference is not None:
             reference = entry.reference.to_pretty_repr()
             lines = reference.splitlines()
-            f.write('    reference = {0}\n'.format(lines[0]))
+            f.write(f'    reference = {lines[0]}\n')
             for line in lines[1:-1]:
-                f.write('    {0}\n'.format(line))
-            f.write('    ),\n'.format(lines[0]))
+                f.write(f'    {line}\n')
+            f.write('    ),\n')
 
         if entry.reference_type != "":
-            f.write('    reference_type = "{0}",\n'.format(entry.reference_type))
+            f.write(f'    reference_type = "{entry.reference_type}",\n')
         if entry.rank is not None:
-            f.write('    rank = {0},\n'.format(entry.rank))
+            f.write(f'    rank = {entry.rank},\n')
 
         if entry.short_desc.strip() != '':
             f.write('    short_desc = u"""')
@@ -390,7 +381,7 @@ class TransitionStateDepository(rmgpy.data.base.Database):
                           short_desc=short_desc, long_desc=long_desc)
 
     def __repr__(self):
-        return '<TransitionStateDepository "{0}">'.format(self.label)
+        return f'<TransitionStateDepository "{self.label}">'
 
     def load(self, path, local_context=None, global_context=None):
 
@@ -420,8 +411,7 @@ class TransitionStateDepository(rmgpy.data.base.Database):
                 reactant = reactant.strip()
                 if reactant not in species_dict:
                     raise rmgpy.data.base.DatabaseError(
-                        'RMGSpecies {0} in kinetics depository {1} is missing from its dictionary.'.format(
-                            reactant, self.label))
+                        f'RMGSpecies {reactant} in kinetics depository {self.label} is missing from its dictionary.')
                 # For some reason we need molecule objects in the depository
                 # rather than species objects
                 rxn.reactants.append(species_dict[reactant])
@@ -429,16 +419,14 @@ class TransitionStateDepository(rmgpy.data.base.Database):
                 product = product.strip()
                 if product not in species_dict:
                     raise rmgpy.data.base.DatabaseError(
-                        'RMGSpecies {0} in kinetics depository {1} is missing from its dictionary.'.format(
-                            product, self.label))
+                        f'RMGSpecies {product} in kinetics depository {self.label} is missing from its dictionary.')
                 # For some reason we need molecule objects in the depository
                 # rather than species objects
                 rxn.products.append(species_dict[product])
 
             if not rxn.is_balanced():
                 raise rmgpy.data.base.DatabaseError(
-                    'Reaction {0} in kinetics depository {1} was not balanced! Please reformulate.'.format(
-                        rxn, self.label))
+                    f'Reaction {rxn} in kinetics depository {self.label} was not balanced! Please reformulate.')
 
     def load_entry(self,
                   index,
@@ -474,7 +462,7 @@ class TransitionStateDepository(rmgpy.data.base.Database):
             long_desc=long_desc.strip(),
             rank=rank,
         )
-        self.entries['{0:d}:{1}'.format(index, label)] = entry
+        self.entries[f'{index:d}:{label}'] = entry
         return entry
 
     def save_entry(self, f, entry):
@@ -499,9 +487,9 @@ class TransitionStateDepository(rmgpy.data.base.Database):
             return [(key, efficiencies[key]) for key in keys]
 
         f.write('entry(\n')
-        f.write('    index = {0:d},\n'.format(entry.index))
+        f.write(f'    index = {entry.index:d},\n')
         if entry.label != '':
-            f.write('    label = "{0}",\n'.format(entry.label))
+            f.write(f'    label = "{entry.label}",\n')
 
         # Entries for kinetic rules, libraries, training reactions
         # and depositories will have a Reaction object for its item
@@ -510,23 +498,17 @@ class TransitionStateDepository(rmgpy.data.base.Database):
             # kinetic rules would have a Group object for its reactants instead of Species
             if isinstance(entry.item.reactants[0], rmgpy.species.Species):
                 # Add degeneracy if the reaction is coming from a depository or kinetics library
-                f.write('    degeneracy = {0:.1f},\n'.format(
-                    entry.item.degeneracy))
+                f.write(f'    degeneracy = {entry.item.degeneracy:.1f},\n')
                 if entry.item.duplicate:
-                    f.write('    duplicate = {0!r},\n'.format(
-                        entry.item.duplicate))
+                    f.write(f'    duplicate = {entry.item.duplicate!r},\n')
                 if not entry.item.reversible:
-                    f.write('    reversible = {0!r},\n'.format(
-                        entry.item.reversible))
+                    f.write(f'    reversible = {entry.item.reversible!r},\n')
                 if entry.item.allow_pdep_route:
-                    f.write('    allow_pdep_route = {0!r},\n'.format(
-                        entry.item.allow_pdep_route))
+                    f.write(f'    allow_pdep_route = {entry.item.allow_pdep_route!r},\n')
                 if entry.item.elementary_high_p:
-                    f.write('    elementary_high_p = {0!r},\n'.format(
-                        entry.item.elementary_high_p))
+                    f.write(f'    elementary_high_p = {entry.item.elementary_high_p!r},\n')
                 if entry.item.allow_max_rate_violation:
-                    f.write('    allow_max_rate_violation = {0!r},\n'.format(
-                        entry.item.allow_max_rate_violation))
+                    f.write(f'    allow_max_rate_violation = {entry.item.allow_max_rate_violation!r},\n')
             # Entries for groups with have a group or logicNode for its item
         elif isinstance(entry.item, rmgpy.molecule.Group):
             f.write('    group = \n')
@@ -534,10 +516,10 @@ class TransitionStateDepository(rmgpy.data.base.Database):
             f.write(entry.item.to_adjacency_list())
             f.write('""",\n')
         elif isinstance(entry.item, rmgpy.data.base.LogicNode):
-            f.write('    group = "{0}",\n'.format(entry.item))
+            f.write(f'    group = "{entry.item}",\n')
         else:
             raise rmgpy.data.base.DatabaseError(
-                "Encountered unexpected item of type {0} while saving database.".format(entry.item.__class__))
+                f"Encountered unexpected item of type {entry.item.__class__} while saving database.")
 
         # Write distances
         if isinstance(entry.data, DistanceData):
@@ -545,7 +527,7 @@ class TransitionStateDepository(rmgpy.data.base.Database):
 
             data_str = data_str.replace('\n', '\n   ')
 
-            f.write('    distances = {},\n'.format(data_str))
+            f.write(f'    distances = {data_str},\n')
         else:
             assert False
 
@@ -553,15 +535,15 @@ class TransitionStateDepository(rmgpy.data.base.Database):
         if entry.reference is not None:
             reference = entry.reference.to_pretty_repr()
             lines = reference.splitlines()
-            f.write('    reference = {0}\n'.format(lines[0]))
+            f.write(f'    reference = {lines[0]}\n')
             for line in lines[1:-1]:
-                f.write('    {0}\n'.format(line))
-            f.write('    ),\n'.format(lines[0]))
+                f.write(f'    {line}\n')
+            f.write('    ),\n')
 
         if entry.reference_type != "":
-            f.write('    reference_type = "{0}",\n'.format(entry.reference_type))
+            f.write(f'    reference_type = "{entry.reference_type}",\n')
         if entry.rank is not None:
-            f.write('    rank = {0},\n'.format(entry.rank))
+            f.write(f'    rank = {entry.rank},\n')
 
         if entry.short_desc.strip() != '':
             f.write('    short_desc = u"""')
@@ -611,7 +593,7 @@ class TSGroups(rmgpy.data.base.Database):
         self.num_reactants = 0
 
     def __repr__(self):
-        return '<TSGroups "{0}">'.format(self.label)
+        return f'<TSGroups "{self.label}">'
 
     def load_entry(
             self,
@@ -707,8 +689,7 @@ class TSGroups(rmgpy.data.base.Database):
         # matched
         if len(template) != len(forward_template):
             logging.warning(
-                'Unable to find matching template for reaction {0} in reaction family {1}'.format(
-                    str(reaction), str(self)))
+                f'Unable to find matching template for reaction {reactin!s} in reaction family {self!s}')
             logging.warning(" Trying to match " + str(forward_template))
             logging.warning(" Matched " + str(template))
             print(str(self), template, forward_template)
@@ -746,14 +727,14 @@ class TSGroups(rmgpy.data.base.Database):
             while not entry.data.distances and entry not in self.top:
                 # Keep climbing tree until you find a (non-top) node with
                 # distances.
-                comment_line += "{0} >> ".format(entry.label)
+                comment_line += f"{entry.label} >> "
                 entry = entry.parent
             if entry.data.distances and entry not in self.top:
                 ts_distances.add(entry.data)
                 comment_line += "{0} ({1})".format(entry.label,
                                                    entry.long_desc.split('\n')[0])
             elif entry in self.top:
-                comment_line += "{0} (Top node)".format(entry.label)
+                comment_line += f"{entry.label} (Top node)"
             ts_distances.comment += comment_line + '\n'
 
         return ts_distances
@@ -837,12 +818,11 @@ class TSGroups(rmgpy.data.base.Database):
                     for group in groups:
                         if isinstance(group, str):
                             group = self.entries[group]
-                        group_comments[group].add("{0!s}".format(template))
+                        group_comments[group].add(f"{template!s}")
 
             if len(A) == 0:
                 logging.warning(
-                    'Unable to fit kinetics groups for family "{0}"; no valid data found.'.format(
-                        self.label))
+                    f'Unable to fit kinetics groups for family "{self.label}"; no valid data found.')
                 return
             A = np.array(A)
             b = np.array(b)
@@ -915,8 +895,7 @@ class TSGroups(rmgpy.data.base.Database):
                     else:
                         uncertainties = {}
                     # should be entry.*
-                    short_desc = "Fitted to {0} distances.\n".format(
-                        group_counts[entry][0])
+                    short_desc = f"Fitted to {group_counts[entry][0]} distances.\n"
                     long_desc = "\n".join(group_comments[entry.label])
                     distances_dict = {key: distance for key, distance in zip(
                         distance_keys, group_values[entry])}

--- a/autotst/data/inputoutput.py
+++ b/autotst/data/inputoutput.py
@@ -91,7 +91,7 @@ class InputOutput():
 
         file_path = os.path.join(self.directory, "ts", self.reaction.label, self.reaction.label + ".log")
         if not os.path.exists(file_path):
-            logging.info("Sorry, we cannot find a valid file path for {}...".format(self.reaction))
+            logging.info(f"Sorry, we cannot find a valid file path for {self.reaction}...")
             self.qmdata = None
             return self.qmdata
         self.qmdata = QMData()
@@ -117,14 +117,14 @@ class InputOutput():
         """
         self.get_qmdata()
         if not self.qmdata:
-            logging.info("No QMData for {}...".format(self.reaction))
+            logging.info(f"No QMData for {self.reaction}...")
             return False
         file_path = self.get_ts_file_path()
-        logging.info("Saving TS result file {}".format(file_path))
+        logging.info(f"Saving TS result file {file_path}")
         with open(file_path, 'w') as results_file:
-            results_file.write('rxn_label = "{0!s}"\n'.format(self.reaction.label))
-            results_file.write('method = "{0!s}"\n'.format(self.method))
-            results_file.write("qm_data = {0!r}\n".format(self.qmdata))
+            results_file.write(f'rxn_label = "{self.reaction.label!s}\"\n')
+            results_file.write(f'method = "{self.method!s}\"\n')
+            results_file.write(f"qm_data = {self.qmdata!r}\n")
         return True
 
     def save_kinetics(self):
@@ -139,13 +139,13 @@ class InputOutput():
             logging.info("The reaction you're trying to save info for doesn't have any kinetic information... aborting.")
             return False
         file_path = self.get_kinetics_file_path()
-        logging.info("Saving kinetics data file {}".format(file_path))
+        logging.info(f"Saving kinetics data file {file_path}")
         with open(file_path, 'w') as result_file:
 
             assert self.reaction.rmg_reaction.kinetics, "No kinetics calclated for this reaction..."
-            result_file.write('method = "{0!s}"\n'.format(self.method))
+            result_file.write(f'method = "{self.method!s}\"\n')
             result_file.write(
-                'reaction = {0!r}\n'.format(self.reaction.rmg_reaction))
+                f'reaction = {self.reaction.rmg_reaction!r}\n')
         return True
 
     def read_ts_file(self, path=None):
@@ -161,11 +161,11 @@ class InputOutput():
         if not path:
             path = self.get_ts_file_path()
         if not os.path.exists(path):
-            logging.info("We could not file a ts file for {}".format(self.reaction.label))
+            logging.info(f"We could not file a ts file for {self.reaction.label}")
             return None
         try:
             with open(path) as result_file:
-                logging.info('Reading existing ts file {0}'.format(path))
+                logging.info(f'Reading existing ts file {path}')
                 global_context = {'__builtins__': None}
                 local_context = {
                     '__builtins__': None,
@@ -177,23 +177,23 @@ class InputOutput():
                 }
                 exec(result_file.read(), global_context, local_context)
         except IOError as e:
-            logging.info("Couldn't read ts file {0}".format(path))
+            logging.info(f"Couldn't read ts file {path}")
             return None
         except (NameError, TypeError, SyntaxError) as e:
-            logging.error('The ts file "{0}" was invalid:'.format(path))
+            logging.error(f'The ts file "{path}" was invalid:')
             logging.exception(e)
             return None
         if 'rxn_label' not in local_context:
             logging.error(
-                'The ts file "{0}" did not contain a rxn_label.'.format(path))
+                f'The ts file "{path}" did not contain a rxn_label.')
             return None
         if 'method' not in local_context:
             logging.error(
-                'The ts file "{0}" did not contain a method.'.format(path))
+                f'The ts file "{path}" did not contain a method.')
             return None
         if 'qm_data' not in local_context:
             logging.error(
-                'The ts file "{0}" did not contain thermo_data.'.format(path))
+                f'The ts file "{path}" did not contain thermo_data.')
             return None
         return local_context
 
@@ -210,11 +210,11 @@ class InputOutput():
         if not path:
             path = self.get_kinetics_file_path()
         if not os.path.exists(path):
-            logging.info("We could not file a kinetics file for {}".format(self.reaction.label))
+            logging.info(f"We could not file a kinetics file for {self.reaction.label}")
             return None
         try:
             with open(path) as result_file:
-                logging.info('Reading existing kinetics file {0}'.format(path))
+                logging.info(f'Reading existing kinetics file {path}')
                 global_context = {'__builtins__': None}
                 local_context = {
                     '__builtins__': None,
@@ -236,18 +236,18 @@ class InputOutput():
                 }
                 exec(result_file.read(), global_context, local_context)
         except IOError as e:
-            logging.error("Couldn't read kinetics file {0}".format(path))
+            logging.error(f"Couldn't read kinetics file {path}")
             return None
         except (NameError, TypeError, SyntaxError) as e:
-            logging.error('The kinetics file "{0}" was invalid:'.format(path))
+            logging.error(f'The kinetics file "{path}" was invalid:')
             logging.exception(e)
             return None
         if 'method' not in local_context:
             logging.error(
-                'The kinetics file "{0}" did not contain a method.'.format(path))
+                f'The kinetics file "{path}" did not contain a method.')
             return None
         if 'Reaction' not in local_context:
             logging.error(
-                'The kinetics file "{0}" did not contain a reaction.'.format(path))
+                f'The kinetics file "{path}" did not contain a reaction.')
             return None
         return local_context

--- a/autotst/data/update.py
+++ b/autotst/data/update.py
@@ -106,7 +106,7 @@ def update_dictionary_entries(old_entries, need_to_add):
             multiplicity = int(
                 re.search('(?<=multiplicity ).*', adjlist).group(0))
             adjlist = re.sub(r'multiplicity .*',
-                             'multiplicity [{}]'.format(multiplicity), adjlist)
+                             f'multiplicity [{multiplicity}]', adjlist)
 
         group = rmgpy.molecule.group.Group()
         group.from_adjacency_list(adjlist)
@@ -135,7 +135,7 @@ def update_dictionary_entries(old_entries, need_to_add):
 
             if group.is_isomorphic(old_entry.item):
                 duplicate = True
-                print('{} found to be duplicate'.format(old_entry))
+                print(f'{old_entry} found to be duplicate')
                 continue
 
             if rel_label not in old_label:
@@ -207,8 +207,7 @@ def rote_load_dict(path):
             if re.search('(?<=multiplicity ).*', adjlist):
                 multiplicity = int(
                     re.search('(?<=multiplicity ).*', adjlist).group(0))
-                adjlist = 'multiplicity [{}]\n'.format(
-                    multiplicity) + adjlist.split('\n', 1)[1]
+                adjlist = f'multiplicity [{multiplicity}]\n' + adjlist.split('\n', 1)[1]
 
             group = rmgpy.molecule.group.Group()
             group.from_adjacency_list(adjlist)
@@ -301,21 +300,21 @@ def update_known_reactions(
             if rel_species not in list(found_species.keys()):
                 need_to_add.append(rel_species.to_smiles())
                 logging.warning(
-                    '{} not found in species dictionary'.format(rel_species))
+                    f'{rel_species} not found in species dictionary')
 
 
         labeled_reactants = [found_species[reactant] for reactant in rmg_reaction.reactants]
         labeled_products = [found_species[product] for product in rmg_reaction.products]
         if len(labeled_reactants) == 2:
-            left_string = "{} + {}".format(labeled_reactants[0], labeled_reactants[1])
+            left_string = f"{labeled_reactants[0]} + {labeled_reactants[1]}"
         else:
-            left_string = "{}".format(labeled_reactants[0])
+            left_string = f"{labeled_reactants[0]}"
         if len(labeled_products) == 2:
-            right_string = "{} + {}".format(labeled_products[0], labeled_products[1])
+            right_string = f"{labeled_products[0]} + {labeled_products[1]}"
         else:
-            right_string = "{}".format(labeled_products[0])
+            right_string = f"{labeled_products[0]}"
 
-        Label = '{} <=> {}'.format(left_string, right_string)
+        Label = f'{left_string} <=> {right_string}'
         #print Label
 
         # adding new entries to r_db, r_db will contain old and new reactions
@@ -338,7 +337,7 @@ def update_known_reactions(
                        rank=None,
                        )
 
-        r_db.entries['{0:d}:{1}'.format(Index + i, Label)].item = rmg_reaction
+        r_db.entries[f'{(Index + i):d}:{Label}'].item = rmg_reaction
 
         # Adding new reactions to the new_r_db as well
         new_r_db.load_entry(Index + i,
@@ -360,8 +359,7 @@ def update_known_reactions(
                            rank=None,
                            )
 
-        new_r_db.entries['{0:d}:{1}'.format(
-            Index + i, Label)].item = rmg_reaction
+        new_r_db.entries[f'{(Index + i):d}:{Label}'].item = rmg_reaction
 
     need_to_add = list(set(need_to_add))
 
@@ -430,8 +428,7 @@ def update_databases(reactions, method='', short_desc='', reaction_family='', ov
 
         updated_known_species = rmgpy.data.base.Database().get_species(new_dict_path)
         unk_spec = get_unknown_species(reactions, updated_known_species)
-        assert len(unk_spec) == 0, '{} unknown species found after updating'.format(
-            len(unk_spec))
+        assert len(unk_spec) == 0, f'{len(unk_spec)} unknown species found after updating'
     else:
         updated_known_species = known_species
 
@@ -450,11 +447,10 @@ def update_databases(reactions, method='', short_desc='', reaction_family='', ov
         if len(reactions) < 5:
             for reaction in reactions:
                 logging.info(
-                    '{} saved and species dictionary updated'.format(reaction))
+                    f'{reaction} saved and species dictionary updated')
         else:
             logging.info(
-                'Reactions and their species saved to...\n{}\n...and...\n{}\n...respectively'.format(
-                    new_reactions_path, new_dict_path))
+                f'Reactions and their species saved to...\n{new_reactions_path}\n...and...\n{new_dict_path}\n...respectively')
     return
 
 ##########################################################################
@@ -480,7 +476,7 @@ def TS_Database_Update(families, path=None, auto_save=False):
         if family.upper() not in (family.upper()
                                   for family in acceptable_families):
             logging.warning(
-                '"{}" is not a known Kinetics Family'.format(family))
+                f'"{family}" is not a known Kinetics Family')
             families.remove(family)
 
     logging.info("Loading RMG Database...")
@@ -502,7 +498,7 @@ def TS_Database_Update(families, path=None, auto_save=False):
                           )
     except BaseException:
         logging.error(
-            "Failed to Load RMG Database at {}".format(database_path))
+            f"Failed to Load RMG Database at {database_path}")
 
     Databases = {family: DatabaseUpdater(
         family, rmg_database, path=path) for family in families}
@@ -586,21 +582,20 @@ class DatabaseUpdater:
         local_context = {'DistanceData': DistanceData}
 
         assert self.family in list(rmg_database.kinetics.families.keys(
-        )), "{} not found in kinetics families. Could not Load".format(family)
+        )), f"{family} not found in kinetics families. Could not Load"
         family = rmg_database.kinetics.families[self.family]
         ts_database.family = family
         ts_database.load(path, local_context, global_context)
         self.database = ts_database
         # Reaction must be a template reaction... found above
 
-        logging.info("Getting Training Data for {}".format(family))
+        logging.info(f"Getting Training Data for {family}")
         training_data = [
             (entry.item, entry.data.distances) for entry in list(
                 ts_database.depository.entries.values())]
 
         self.training_set = training_data
-        logging.info("Total Distances Count: {}".format(
-            len(self.training_set)))
+        logging.info(f"Total Distances Count: {len(self.training_set)}")
 
         return
 
@@ -624,7 +619,7 @@ class DatabaseUpdater:
 
         self.all_entries = all_entries
         logging.info("Updating Indices based off of Tree...")
-        logging.info("Tree size: {}".format(len(all_entries)))
+        logging.info(f"Tree size: {len(all_entries)}")
         return
 
     def set_group_info(self):
@@ -689,9 +684,8 @@ class DatabaseUpdater:
         self.group_ancestors = all_ancestors
         self.reaction_templates = all_reactant_groups
 
-        logging.info('Nodes to Update: {}'.format(len(self.nodes_to_update)))
-        logging.info("Reaction Templates: {}".format(
-            len(self.reaction_templates)))
+        logging.info(f'Nodes to Update: {len(self.nodes_to_update)}')
+        logging.info(f"Reaction Templates: {len(self.reaction_templates)}")
         return
 
     def initialize_entry_attributes(self):
@@ -764,7 +758,7 @@ class DatabaseUpdater:
                     if isinstance(group, str):
                         assert False, "Discrepancy between versions of RMG_Database and this one"
 
-                    self.group_comments[group].add('{0!s}'.format(template))
+                    self.group_comments[group].add(f'{template!s}')
 
         self.A = np.array(A)
         self.b = np.array(b)
@@ -855,8 +849,7 @@ class DatabaseUpdater:
                     else:
                         uncertainties = {}
                     # should be entry.*
-                    short_desc = "Fitted to {0} distances.\n".format(
-                        self.group_counts[entry][0])
+                    short_desc = f"Fitted to {self.group_counts[entry][0]} distances.\n"
                     long_desc = "\n".join(self.group_comments[entry])
                     distances_dict = {key: distance for key, distance in zip(
                         distance_keys, self.group_values[entry])}
@@ -872,7 +865,7 @@ class DatabaseUpdater:
                 else:
                     entry.data = DistanceData()
                     entry.long_desc = ''
-        logging.info("Finished Updating Entries for {}\n".format(self.family))
+        logging.info(f"Finished Updating Entries for {self.family}\n")
         return
 
     def save_database(self, path=None):
@@ -887,5 +880,5 @@ class DatabaseUpdater:
             path = os.path.join(self.path, 'TS_groups.py')
 
         self.database.save_transition_state_groups(path)
-        logging.info('Saved {} Database to: {}'.format(self.family, path))
+        logging.info(f'Saved {self.family} Database to: {path}')
         return

--- a/autotst/geometry.py
+++ b/autotst/geometry.py
@@ -50,7 +50,7 @@ class Bond:
         self.mask = mask
 
     def __repr__(self):
-        return '<Bond "{}">'.format(self.atom_indices)
+        return f'<Bond "{self.atom_indices}">'
 
 
 class Angle():
@@ -80,7 +80,7 @@ class Angle():
         self.reaction_center = reaction_center
 
     def __repr__(self):
-        return '<Angle "{0}">'.format(self.atom_indices)
+        return f'<Angle "{self.atom_indices}">'
 
 
 class Torsion():
@@ -110,7 +110,7 @@ class Torsion():
         self.reaction_center = reaction_center
 
     def __repr__(self):
-        return '<Torsion "{0}">'.format(self.atom_indices)
+        return f'<Torsion "{self.atom_indices}">'
 
 
 class CisTrans():
@@ -143,7 +143,7 @@ class CisTrans():
         self.reaction_center = reaction_center
 
     def __repr__(self):
-        return '<CisTrans "{0} - {1}">'.format(self.atom_indices, self.stero)
+        return f'<CisTrans "{self.atom_indices} - {self.stero}">'
 
 
 class ChiralCenter():

--- a/autotst/geometry.py
+++ b/autotst/geometry.py
@@ -162,5 +162,4 @@ class ChiralCenter():
         self.chirality = chirality
 
     def __repr__(self):
-        return '<ChiralCenter "{0} - {1}">'.format(
-            self.atom_index, self.chirality)
+        return f'<ChiralCenter "{self.atom_index} - {self.chirality}">'

--- a/autotst/job/job_test.py
+++ b/autotst/job/job_test.py
@@ -113,13 +113,13 @@ class JobTest(unittest.TestCase):
         self.reaction.generate_reactants_and_products()
         conformer = list(self.reaction.reactants[0].conformers.values())[0][0]
         label = self.job.submit_conformer(conformer)
-        self.assertEqual(label, "{}_{}".format(conformer.smiles , conformer.index))
+        self.assertEqual(label, f"{conformer.smiles}_{conformer.index}")
 
     def test_submit_conformer2(self):
         self.reaction.generate_reactants_and_products()
         conformer = list(self.reaction.reactants[0].conformers.values())[0][0]
         label = self.job2.submit_conformer(conformer)
-        self.assertEqual(label, "{}_{}".format(conformer.smiles , conformer.index))
+        self.assertEqual(label, f"{conformer.smiles}_{conformer.index}")
 
     def test_calculate_conformer(self):
         conformer = Conformer(smiles='CC',index=0)
@@ -144,9 +144,9 @@ class JobTest(unittest.TestCase):
         for opt_type in ["shell", "center", "overall"]:
             label = self.job.submit_transitionstate(ts, opt_type=opt_type)
             if opt_type == "overall":
-                self.assertEqual(label, "{}_{}_{}".format(ts.reaction_label,ts.direction, ts.index))
+                self.assertEqual(label, f"{ts.reaction_label}_{ts.direction}_{ts.index}")
             else:
-                self.assertEqual(label, "{}_{}_{}_{}".format(ts.reaction_label,ts.direction, opt_type, ts.index))
+                self.assertEqual(label, f"{ts.reaction_label}_{ts.direction}_{opt_type}_{ts.index}")
 
     def test_submit_transitionstate2(self):
         ts = self.reaction.ts["forward"][0]
@@ -154,9 +154,9 @@ class JobTest(unittest.TestCase):
         for opt_type in ["shell", "center", "overall"]:
             label = self.job2.submit_transitionstate(ts, opt_type=opt_type)
             if opt_type == "overall":
-                self.assertEqual(label, "{}_{}_{}".format(ts.reaction_label,ts.direction, ts.index))
+                self.assertEqual(label, f"{ts.reaction_label}_{ts.direction}_{ts.index}")
             else:
-                self.assertEqual(label, "{}_{}_{}_{}".format(ts.reaction_label,ts.direction, opt_type, ts.index))
+                self.assertEqual(label, f"{ts.reaction_label}_{ts.direction}_{opt_type}_{ts.index}")
 
     def test_calculate_transitionstate(self):
         ts = self.reaction.ts["forward"][0]

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -88,7 +88,7 @@ class Reaction():
         self._distance_data = None
 
     def __repr__(self):
-        return '<Reaction "{}">'.format(self.label)
+        return f'<Reaction "{self.label}">'
 
     @property
     def ts(self):
@@ -163,7 +163,7 @@ class Reaction():
         else:
             database_path = rmg_database_path
 
-        logging.info("Loading RMG database from '{}'".format(database_path))
+        logging.info(f"Loading RMG database from '{database_path}'")
 
         self.possible_families = [  # These families (and only these) will be loaded from both RMG and AutoTST databases
             "R_Addition_MultipleBond",
@@ -185,11 +185,11 @@ class Reaction():
             )
         except IOError:
             logging.info(
-                "RMG database not found at '{}'. This can occur if a git repository of the database is being"
-                "used rather than the binary version".format(database_path))
+                f"RMG database not found at '{database_path}'. "
+                "This can occur if a git repository of the database is being used rather than the binary version")
             database_path = os.path.join(database_path, 'input')
             logging.info(
-                "Loading RMG database instead from '{}'".format(database_path))
+                f"Loading RMG database instead from '{database_path}'")
             rmg_database.load(
                 database_path,
                 kinetics_families=self.possible_families,
@@ -248,8 +248,7 @@ class Reaction():
 
             self._distance_data.distances["d13"] -= self._distance_data.uncertainties["d13"] / 2
 
-        logging.info("The distance data is as follows: {}".format(
-            self._distance_data))
+        logging.info(f"The distance data is as follows: {self._distance_data}")
 
         return self._distance_data
 
@@ -326,7 +325,7 @@ class Reaction():
 
             # looping though each reaction family and each combination of reactants and products
             for name, family in list(self.rmg_database.kinetics.families.items()):
-                logging.info("Trying to match reacction to {}".format(family))
+                logging.info(f"Trying to match reacction to {family}")
                 for rmg_reactants, rmg_products in combos_to_try:
                     # Making a test reaction
                     test_reaction = rmgpy.reaction.Reaction(
@@ -337,7 +336,7 @@ class Reaction():
                         labeled_r, labeled_p = family.get_labeled_reactants_and_products(
                             test_reaction.reactants, test_reaction.products)
                     except: # Failed to match a reaction to the family
-                        logging.error("Couldn't match {} to {}, trying different combination...".format(test_reaction, name))
+                        logging.error(f"Couldn't match {test_reaction} to {name}, trying different combination...")
                         continue
                         
                     if not (labeled_r and labeled_p):
@@ -354,7 +353,7 @@ class Reaction():
                             logging.warning("Skipping this duplicate for now")
                             continue
 
-                        logging.info("Matched reaction to {} family".format(name))
+                        logging.info(f"Matched reaction to {name} family")
                         
                         # Copying labed reactions and saving them for later
                         labeled_reactants = deepcopy(labeled_r)
@@ -390,7 +389,7 @@ class Reaction():
             ))
 
             for name, family in list(self.rmg_database.kinetics.families.items()):
-                logging.info("Trying to match reaction to {}".format(name))
+                logging.info(f"Trying to match reaction to {name}")
                 for rmg_reactants, rmg_products in combos_to_try:
                     # Making a test reaction
                     test_reaction = rmgpy.reaction.Reaction(
@@ -410,7 +409,7 @@ class Reaction():
                             labeled_r, labeled_p = family.get_labeled_reactants_and_products(
                                 test_reaction.products, test_reaction.reactants)
                         except:
-                            logging.error("Couldn't match {} to {}, trying different combination...".format(test_reaction, name))
+                            logging.error(f"Couldn't match {test_reaction} to {name}, trying different combination...")
                             continue
                         
                     if not (labeled_r and labeled_p):
@@ -427,7 +426,7 @@ class Reaction():
                             logging.warning("Skipping this duplicate for now")
                             continue
 
-                        logging.info("Matched reaction to {} family".format(name))
+                        logging.info(f"Matched reaction to {name} family")
                         
                         # Copying labed reactions and saving them for later
                         labeled_reactants = deepcopy(labeled_r)
@@ -473,16 +472,16 @@ class Reaction():
         string = ""
         for react in self.rmg_reaction.reactants:
             if isinstance(react, rmgpy.species.Species):
-                string += "{}+".format(react.molecule[0].to_smiles())
+                string += f"{react.molecule[0].to_smiles()}+"
             elif isinstance(react, rmgpy.molecule.Molecule):
-                string += "{}+".format(react.to_smiles())
+                string += f"{react.to_smiles()}+"
         string = string[:-1]
         string += "_"
         for prod in self.rmg_reaction.products:
             if isinstance(prod, rmgpy.species.Species):
-                string += "{}+".format(prod.molecule[0].to_smiles())
+                string += f"{prod.molecule[0].to_smiles()}+"
             elif isinstance(prod, rmgpy.molecule.Molecule):
-                string += "{}+".format(prod.to_smiles())
+                string += f"{prod.to_smiles()}+"
         self.label = string[:-1]
         return self.label
 
@@ -637,7 +636,7 @@ class TS(Conformer):
             self._symmetry_number = None
 
     def __repr__(self):
-        return '<TS "{}">'.format(self.smiles)
+        return f'<TS "{self.smiles}">'
 
     def copy(self):
         copy_conf = TS(
@@ -738,8 +737,7 @@ class TS(Conformer):
         :return bm: an array of arrays corresponding to the edited bounds matrix
         """
         logging.info(
-            "For atoms {0} and {1} we have a distance of: \t {2}".format(
-                lbl1, lbl2, value))
+            f"For atoms {lbl1} and {lbl2} we have a distance of: \t {value}")
         if lbl1 > lbl2:
             self.bm[lbl2][lbl1] = value + uncertainty / 2
             self.bm[lbl1][lbl2] = max(0, value - uncertainty / 2)
@@ -774,7 +772,7 @@ class TS(Conformer):
                     max_lij = u_ik + u_kj - 0.1
                     if self.bm[i, j] > max_lij:
                         logging.info(
-                            "Changing lower limit {0} to {1}".format(self.bm[i, j], max_lij))
+                            f"Changing lower limit {self.bm[i, j]} to {max_lij}")
                         self.bm[i, j] = max_lij
 
         return self.bm
@@ -810,7 +808,7 @@ class TS(Conformer):
             labels = [lbl1, lbl2, lbl3]
             atom_match = ((lbl1,), (lbl2,), (lbl3,))
 
-        #logging.info("The labled atoms are {}.".format(labels))
+        #logging.info(f"The labled atoms are {labels}.")
         self.labels = labels
         self.atom_match = atom_match
         return self.labels, self.atom_match
@@ -902,8 +900,7 @@ class TS(Conformer):
                     break
                 except ValueError:
                     logging.info(
-                        "RDKit failed to embed on attempt {0} of {1}".format(
-                            i + 1, num_conf_attempts))
+                        f"RDKit failed to embed on attempt {i + 1} of {num_conf_attempts}")
                 except RuntimeError:
                     logging.info("RDKit failed to embed.")
             else:

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -168,7 +168,7 @@ class Species():
         for s in self.smiles:
             string += s + " / "
 
-        return '<Species "{}">'.format(string[:-3])
+        return f'<Species "{string[:-3]}">'
 
     @property
     def conformers(self):
@@ -240,7 +240,7 @@ class Conformer():
             self._symmetry_number = None
 
     def __repr__(self):
-        return '<Conformer "{}">'.format(self.smiles)
+        return f'<Conformer "{self.smiles}">'
 
     def copy(self):
         copy_conf = Conformer()
@@ -830,8 +830,7 @@ class Conformer():
 
         possible_mol_types = ["ase", "rmg", "rdkit"]
 
-        assert (mol_type.lower() in possible_mol_types), "Please specifiy a valid mol type. Valid types are {}".format(
-            possible_mol_types)
+        assert (mol_type.lower() in possible_mol_types), f"Please specifiy a valid mol type. Valid types are {possible_mol_types}"
 
         if mol_type.lower() == "rmg":
             conf = self.rdkit_molecule.GetConformers()[0]


### PR DESCRIPTION
These are nicer to look at, easier to debug, etc.

I did these using the "convert to f-string literal" code intention
in PyCharm. Click inside a .format() string somewhere and press
Alt-Enter on your keyboard, then select "convert to f-string literal".

This first commit I just did a couple of files.

There are probably some tools to do it faster than one at a time,
like https://github.com/asottile/pyupgrade

Think about when best to do this in regards other open pull requests, to minimize merge conflicts.
But I think it's worth doing - either with one concerted effort or gradually as you touch code.