### PR TITLE
linear torsion angle fix

### DIFF
--- a/autotst/geometry.py
+++ b/autotst/geometry.py
@@ -102,14 +102,16 @@ class Torsion():
             dihedral,
             index = -1,
             mask = [],
+            center_atoms = [],
             description = 'hindered',
-            reaction_center = False,
-            center_atoms = []):
+            reaction_center = False
+            ):
 
-        self.index = index
         self.atom_indices = atom_indices
         self.dihedral = dihedral
+        self.index = index
         self.mask = mask
+        self.center_atoms = center_atoms
         self.description = description.lower()
         self.reaction_center = reaction_center
         

--- a/autotst/geometry.py
+++ b/autotst/geometry.py
@@ -98,17 +98,22 @@ class Torsion():
 
     def __init__(
             self,
-            index,
             atom_indices,
             dihedral,
-            mask,
-            reaction_center=False):
+            index = -1,
+            mask = [],
+            description = 'hindered',
+            reaction_center = False,
+            center_atoms = []):
+
         self.index = index
         self.atom_indices = atom_indices
         self.dihedral = dihedral
         self.mask = mask
+        self.description = description.lower()
+        self.center_atoms = center_atoms
         self.reaction_center = reaction_center
-
+        
     def __repr__(self):
         return f'<Torsion "{self.atom_indices}">'
 

--- a/autotst/geometry.py
+++ b/autotst/geometry.py
@@ -111,7 +111,6 @@ class Torsion():
         self.dihedral = dihedral
         self.mask = mask
         self.description = description.lower()
-        self.center_atoms = center_atoms
         self.reaction_center = reaction_center
         
     def __repr__(self):

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -758,12 +758,17 @@ class Conformer():
         """
 
         rdkit_atoms = self.rdkit_molecule.GetAtoms()
-        if (isinstance(geometry, autotst.geometry.Torsion) or
-                isinstance(geometry, autotst.geometry.CisTrans)):
+        if isinstance(geometry, autotst.geometry.Torsion):
 
             L1, L0, R0, R1 = geometry.atom_indices
 
-            # trying to get the left hand side of this torsion
+            LHS_atoms_index = [L0, L1] + geometry.center_atoms
+            RHS_atoms_index = [R0, R1]
+
+        elif isinstance(geometry, autotst.geometry.CisTrans):
+
+            L1, L0, R0, R1 = geometry.atom_indices
+
             LHS_atoms_index = [L0, L1]
             RHS_atoms_index = [R0, R1]
 

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -433,12 +433,35 @@ class Conformer():
         self.angles = angles
         return self.angles
 
-    def get_torsions(self):
+    def get_torsions(self,tol=5.0):
         """
         A method for identifying all of the torsions in a conformer
         """
+
+        def check_angles(tor):
+            """
+            Checks for linearity in torsion angles.  If angle is close to 180 degrees, 
+            the tuple index corresponding to the the endpoint atom of that angle is returned in a list.
+            """
+            i,j,k,l = tor
+            angles = ((0,self.ase_molecule.get_angle(i, j, k)), (-1,self.ase_molecule.get_angle(j, k, l)))
+            endpoints = []
+            for index,angle in angles:
+                if abs(angle-180) <= tol:  # we have a linear angle and invalid torsion
+                    endpoints.append(index)
+            return endpoints
+
         torsion_list = []
+        if self.rmg_molecule.is_linear(): # No torsions if linear molecule
+            self.torsions  = []
+            return []
+
         for bond1 in self.rdkit_molecule.GetBonds():
+            
+            # Make sure the bond is single and rotatable
+            if str(bond1.GetBondType()) != 'SINGLE':
+                continue
+
             atom1 = bond1.GetBeginAtom()
             atom2 = bond1.GetEndAtom()
             if atom1.IsInRing() or atom2.IsInRing():
@@ -465,22 +488,17 @@ class Conformer():
 
             for bond0 in bond_list1:
                 atomX = bond0.GetOtherAtom(atom1)
-                # if atomX.GetAtomicNum() == 1 and len(atomX.GetBonds()) == 1:
-                # This means that we have a terminal hydrogen, skip this
-                # NOTE: for H_abstraction TSs, a non teminal H should exist
-                #    continue
                 if atomX.GetIdx() != atom2.GetIdx():
                     got_atom0 = True
                     atom0 = atomX
+                    break
 
             for bond2 in bond_list2:
                 atomY = bond2.GetOtherAtom(atom2)
-                # if atomY.GetAtomicNum() == 1 and len(atomY.GetBonds()) == 1:
-                # This means that we have a terminal hydrogen, skip this
-                #    continue
                 if atomY.GetIdx() != atom1.GetIdx():
                     got_atom3 = True
                     atom3 = atomY
+                    break
 
             if not (got_atom0 and got_atom3):
                 # Making sure atom0 and atom3 were not found
@@ -503,37 +521,73 @@ class Conformer():
                 torsion_tup = (atom0.GetIdx(), atom1.GetIdx(),
                                atom2.GetIdx(), atom3.GetIdx())
 
-                already_in_list = False
-                for torsion_entry in torsion_list:
-                    a, b, c, d = torsion_entry
-                    e, f, g, h = torsion_tup
+                endpoints = check_angles(torsion_tup) # check to see if we have any near-linear angles
+                center_atoms = []
+                valid_torsion = True
+   
+                while len(endpoints) > 0: # while we have a near-linear angle in the torsion...
+                    
+                    reached_the_end = [False for i in range(len(endpoints))] 
+                    for i,index in enumerate(endpoints):
+                        if index == 0: # angle i,j,k is near-linear
+                            vertex = torsion_tup[1] # vertex of angle is j
+                        else:  # angle j,k,l is near-linear
+                            vertex = torsion_tup[2] # vertex of angle is k
+                        atom_id = torsion_tup[index] # index of endpoint atom (i or l)
+                        atom = self.rdkit_molecule.GetAtomWithIdx(atom_id) # retrieve endpoint atom
+                        bonds = list(atom.GetBonds()) # get atoms connected to endpoint atoms
+                        got_one = False
+                        for bond in bonds:
+                            atomX = bond.GetOtherAtom(atom)
+                            if atomX.GetIdx() != vertex: # make sure we do not go backwards
+                                got_one = True
+                                break
+            
+                        if got_one is True: # we found a new atom
+                            if index == 0:  # angle i,j,k was near-linear
+                                center_atoms.append(torsion_tup[1]) # we are skipping over j and adding to center atoms
+                                torsion_tup = (atomX.GetIdx(),) + \
+                                (torsion_tup[0], torsion_tup[2], torsion_tup[3]) # new torsion atom indicies
+                            else:  # angle j,k,l was near-linear
+                                center_atoms.append(torsion_tup[2])  # we are skipping over k and adding to center atoms
+                                torsion_tup = (
+                                    torsion_tup[0], torsion_tup[1], torsion_tup[3]) \
+                                    + (atomX.GetIdx(),) # new torsion atom indicies
+                        else: # we did not find a new atom because atom endpoint atom is terminal
+                            reached_the_end[i] = True # we reached the end of the molecule
 
-                    if (b, c) == (f, g) or (b, c) == (g, f):
+                    if all(reached_the_end): # We reached the end of the molecule and still have linear angle
+                        valid_torsion = False
+                        break
+                    
+                    endpoints = check_angles(torsion_tup)
+
+                if not valid_torsion:
+                    continue
+
+                already_in_list = False
+                i, j, k, l = torsion_tup
+                for torsion in torsion_list:
+                    a, b, c, d = torsion.atom_indices
+                    if (b, c) == (j, k) or (b, c) == (k, j):
                         already_in_list = True
+                        break
 
                 if not already_in_list:
-                    torsion_list.append(torsion_tup)
+                    dihedral = self.ase_molecule.get_dihedral(i, j, k, l)
+                    tor = Torsion(atom_indices=torsion_tup,
+                                  dihedral=dihedral,
+                                  center_atoms=center_atoms,
+                                  reaction_center=False,
+                                  )
+                    torsion_list.append(tor)
 
-        torsions = []
-        for index, indices in enumerate(torsion_list):
-            i, j, k, l = indices
-
-            dihedral = self.ase_molecule.get_dihedral(i, j, k, l)
-            tor = Torsion(index=index,
-                          atom_indices=indices,
-                          dihedral=dihedral,
-                          mask=[])
-            mask = self.get_mask(tor)
-            reaction_center = False
-
-            torsions.append(Torsion(index=index,
-                                    atom_indices=indices,
-                                    dihedral=dihedral,
-                                    mask=mask,
-                                    reaction_center=reaction_center))
-
-        self.torsions = torsions
-        return self.torsions
+        for index, tor in enumerate(torsion_list):
+            tor.index = index
+            tor.mask = self.get_mask(tor)
+        
+        self.torsions = torsion_list
+        return torsion_list
 
     def get_cistrans(self):
         """

--- a/autotst/species_test.py
+++ b/autotst/species_test.py
@@ -44,6 +44,7 @@ from .species import Species, Conformer
 class TestConformer(unittest.TestCase):
     def setUp(self):
         self.conformer = Conformer(smiles='CC')
+        self.conformer_torsion_test = Conformer(smiles='CC#CC')
     def test_rmg_molecules(self):
         self.assertIsInstance(self.conformer.rmg_molecule,rmgpy.molecule.Molecule)
     def test_rdkit_mol(self):
@@ -67,10 +68,13 @@ class TestConformer(unittest.TestCase):
         self.assertIsInstance(angles[0],Angle)
         self.assertEquals(len(angles),12)
     def test_get_torsions(self):
-        torsions = self.conformer.get_torsions()
+        torsions = self.conformer_torsion_test.get_torsions()
         self.assertIsInstance(torsions,list)
-        self.assertIsInstance(torsions[0],Torsion)
-        self.assertEquals(len(torsions),1)
+        self.assertEquals(len(torsions), 1)
+        torsion = torsions[0]
+        self.assertIsInstance(torsion, Torsion)
+        self.assertEquals(len(torsion.center_atoms),2)
+        self.assertEquals(len(torsion.mask).count(True),4)
     def test_get_cistrans(self):
         cistrans = self.conformer.get_cistrans()
         self.assertIsInstance(cistrans,list)

--- a/autotst/species_test.py
+++ b/autotst/species_test.py
@@ -74,7 +74,7 @@ class TestConformer(unittest.TestCase):
         torsion = torsions[0]
         self.assertIsInstance(torsion, Torsion)
         self.assertEquals(len(torsion.center_atoms),2)
-        self.assertEquals(len(torsion.mask).count(True),4)
+        self.assertEquals(torsion.mask.count(True),4)
     def test_get_cistrans(self):
         cistrans = self.conformer.get_cistrans()
         self.assertIsInstance(cistrans,list)


### PR DESCRIPTION
I added a method within `get_torsions` that checks for linear (or near-linear within a tolerance) angles in a torsion.  If an angle is near 180 degrees, we look farther down the molecule for an atom to define the torsion.  I also added `angles`, `description`, and `center_atoms` attribute to torsion class.  