### PR TITLE
try is_linear()

### DIFF
--- a/autotst/species.py
+++ b/autotst/species.py
@@ -452,9 +452,13 @@ class Conformer():
             return endpoints
 
         torsion_list = []
-        if self.rmg_molecule.is_linear(): # No torsions if linear molecule
-            self.torsions  = []
-            return []
+
+        try:
+            if self.rmg_molecule.is_linear(): # No torsions if linear molecule
+                self.torsions  = []
+                return []
+        except:
+            pass
 
         for bond1 in self.rdkit_molecule.GetBonds():
             


### PR DESCRIPTION
`conformer.rmg_molecule.is_linear()` raises `IndexError` for autotst TS's that have atoms with no bonds such as an H_Abstraction by an atom (H, F, Cl, or Br).  This commit adds a try and except block to keep it from crashing.  