### PR TITLE
Fix-ups to Vibrational Analysis 

### DIFF
--- a/autotst/calculator/vibrational_analysis.py
+++ b/autotst/calculator/vibrational_analysis.py
@@ -188,6 +188,10 @@ class VibrationalAnalysis():
             if bond.reaction_center:
                 labels = sorted([self.ts.rmg_molecule.atoms[i].label.lstrip('*'), self.ts.rmg_molecule.atoms[j].label.lstrip('*')])
                 key = f'd{labels[0]}{labels[1]}'
+                if key == 'd24':
+                    key = 'd12'
+                elif key == 'd14':
+                    key = 'd23'
                 reference_distance = self.ts.distance_data.distances[key] * 1.25
                 if before > reference_distance:
                     logging.error(f'{key} distance is too large, it was measured at {before} Å when the maximum allowable distance is {reference_distance} Å.')

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -687,13 +687,22 @@ class TS(Conformer):
             rd_copy = rdkit.Chem.RWMol(self.rdkit_molecule.__copy__())
 
             lbl1, lbl2, lbl3 = self.labels
-
-            if not rd_copy.GetBondBetweenAtoms(lbl1, lbl2):
-                rd_copy.AddBond(lbl1, lbl2,
-                                order=rdkit.Chem.rdchem.BondType.SINGLE)
-            elif not rd_copy.GetBondBetweenAtoms(lbl2, lbl3):
-                rd_copy.AddBond(lbl2, lbl3,
-                                order=rdkit.Chem.rdchem.BondType.SINGLE)
+            if self.reaction_family.lower() in ['h_abstraction', 'r_addition_multiplebond', 'disproportionation']:
+                # We draw a psuedo bond between *1-*2 and *2-*3
+                if not rd_copy.GetBondBetweenAtoms(lbl1, lbl2):
+                    rd_copy.AddBond(lbl1, lbl2,
+                                    order=rdkit.Chem.rdchem.BondType.SINGLE)
+                elif not rd_copy.GetBondBetweenAtoms(lbl2, lbl3):
+                    rd_copy.AddBond(lbl2, lbl3,
+                                    order=rdkit.Chem.rdchem.BondType.SINGLE)
+            elif self.reaction_family.lower() == 'intra_h_migration':
+                # We draw a pseudo bond between *1-*3 and *3-*2 
+                if not rd_copy.GetBondBetweenAtoms(lbl1, lbl3):
+                    rd_copy.AddBond(lbl1, lbl3,
+                                    order=rdkit.Chem.rdchem.BondType.SINGLE)
+                elif not rd_copy.GetBondBetweenAtoms(lbl2, lbl3):
+                    rd_copy.AddBond(lbl2, lbl3,
+                                    order=rdkit.Chem.rdchem.BondType.SINGLE)
             
 
             self._pseudo_geometry = rd_copy

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -378,9 +378,6 @@ class Conformer():
 
             length = self.ase_molecule.get_distance(i, j)
             center = False
-            if ((self.rmg_molecule.atoms[i].label) and (
-                    self.rmg_molecule.atoms[j].label)):
-                center = True
 
             bond = Bond(index=index,
                         atom_indices=indices,


### PR DESCRIPTION
After investigating failed AutoTST jobs, it was appearing that our vibrational analysis needed a touch of work. After looking through the code, I noticed a few issues:

1) We were incorrectly labeling bonds in the reaction center for migration reactions.
3) The pseudo rdkit molecule that we created for migration reactions was incorrect. In most cases, the *2 atom is our H being abstracted, but in migration reactions, the *3 atom is that H. 
1) We were not checking that reacting atoms were close enough to each other to react.
2) We were not checking if vibrations in the reaction center were above a specific amount and vibrations in the shell were below a specific amount.

This PR addresses these issues by:

1) Fixing the identification of reacting bonds.
2) Correctly creates our pseudo rdkit geometry.
3) Checks that active bonds are within 1.25x their predicted amount (e.g. if d12=1.5Å from our estimates and if measured d12<=1.25x 1.5 Å then we say that the atoms are close enough to actually interact).
4) Check that the average bond length in the reaction center changes by at least 15% and that the average bond length in the shell changes by no more than 5%.