### PR TITLE
FixUp to Errors introduced in recent Vibrational Analysis PRs

### DIFF
--- a/autotst/calculator/gaussian_test.py
+++ b/autotst/calculator/gaussian_test.py
@@ -52,6 +52,7 @@ class TestGaussian(unittest.TestCase):
         rxn = Reaction(label='C+[O]O_[CH3]+OO')
         ts = rxn.ts["forward"][0]
         ts.get_molecules()
+        ts.get_geometries()
         self.gaussian = Gaussian(conformer=ts)
     def test_rotor_calc(self):
         autotst_gaussian_rotor = self.gaussian.get_rotor_calc()

--- a/autotst/calculator/vibrational_analysis.py
+++ b/autotst/calculator/vibrational_analysis.py
@@ -62,6 +62,7 @@ class VibrationalAnalysis():
         - log_file (str): path to the TS log file
         """
         self.ts = transitionstate
+        self.ts.get_molecules()
         self.ts.get_geometries()
         self.directory = directory
 

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -610,6 +610,7 @@ class TS(Conformer):
         self.distance_data = distance_data
         self.index = index
         self.bm = None
+        self.labels = None
         self.action = action
 
         assert direction in ["forward",
@@ -675,6 +676,8 @@ class TS(Conformer):
     def rdkit_molecule(self):
         if (self._rdkit_molecule is None) and self.distance_data:
             self._rdkit_molecule = self.get_rdkit_mol()
+        if (self._pseudo_geometry is None):
+            self.get_pseudo_geometry()
         return self._rdkit_molecule
 
     @property

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -617,6 +617,13 @@ class TS(Conformer):
 
         self._rdkit_molecule = None
         self._ase_molecule = None
+        self._pseudo_geometry = None
+        self.bonds = []
+        self.angles = []
+        self.torsions = []
+        self.cistrans = []
+        self.chiral_centers = []
+        self._symmetry_number = None
 
         if (smiles or rmg_molecule):
             if smiles and rmg_molecule:
@@ -639,15 +646,6 @@ class TS(Conformer):
         else:
             self.smiles = None
             self.rmg_molecule = None
-            self._rdkit_molecule = None
-            self._pseudo_geometry = None
-            self._ase_molecule = None
-            self.bonds = []
-            self.angles = []
-            self.torsions = []
-            self.cistrans = []
-            self.chiral_centers = []
-            self._symmetry_number = None
 
     def __repr__(self):
         return f'<TS "{self.smiles}">'

--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -683,20 +683,16 @@ class TS(Conformer):
             self._ase_molecule = self.get_ase_mol()
         return self._ase_molecule
 
-    def get_rdkit_mol(self):
+    def get_pseudo_geometry(self):
         """
-        A method to create an rdkit geometry... slightly different than that of the conformer method
-        returns both the rdkit_molecule and the bm
+        A method to create a _pseduo_geometry. Essentailly an RDKit molecule with a fake bond drawn
+        between reacting atoms which are not bound to be used in other processes 
         """
-        self._rdkit_molecule = Conformer(rmg_molecule=self.rmg_molecule).get_rdkit_mol()
-
-        self.get_labels()
-        for i, atom in enumerate(self.rmg_molecule.atoms):
-            assert atom.number == self.rdkit_molecule.GetAtoms()[i].GetAtomicNum()
-
+        if self.labels is None:
+            self.get_labels()
         if len(self.labels) == 3:
 
-            rd_copy = rdkit.Chem.RWMol(self.rdkit_molecule.__copy__())
+            rd_copy = rdkit.Chem.RWMol(self._rdkit_molecule.__copy__())
 
             for a in self.action:
                 if 'BOND' in a[0]:
@@ -707,6 +703,23 @@ class TS(Conformer):
                         rd_copy.AddBond(sorting_label_1, sorting_label_2, order=rdkit.Chem.rdchem.BondType.SINGLE)
 
             self._pseudo_geometry = rd_copy
+        else:
+            logging.warning('There are not 3 labels, setting the _pseudo_geometry to the unedited rdkit molecule')
+            self._pseudo_geometry =  self.rdkit_molecule
+        return self._pseudo_geometry
+        
+
+    def get_rdkit_mol(self):
+        """
+        A method to create an rdkit geometry... slightly different than that of the conformer method
+        returns both the rdkit_molecule and the bm
+        """
+        self._rdkit_molecule = Conformer(rmg_molecule=self.rmg_molecule).get_rdkit_mol()
+
+        if self.labels is None:
+            self.get_labels()
+        for i, atom in enumerate(self.rmg_molecule.atoms):
+            assert atom.number == self.rdkit_molecule.GetAtoms()[i].GetAtomicNum()
 
         logging.info("Initially embedded molecule")
 

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -348,7 +348,6 @@ class Conformer():
             self.rmg_molecule = rmgpy.molecule.Molecule(smiles=self.smiles)
         self._rdkit_molecule = self.get_rdkit_mol()
         self._ase_molecule = self.get_ase_mol()
-        self.get_geometries()
 
         return self.rdkit_molecule, self.ase_molecule
 


### PR DESCRIPTION
A few previous PRs made errors occur when a user tried to call Vibrational Analysis methods. This PR addresses them by doing the following:

- Separates the creation of the `TS._pesudo_geometry` (used for Vibrational Analysis) and the creation of the `TS.rdkit_molecule` (used in geometry optimizations.
- Adds a line of code needed to correct the introduced error from before.