### PR TITLE
Fix of Conformer Analysis Issues for Migration TSs

### DIFF
--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -71,7 +71,6 @@ def find_all_combos(
     conformer.get_geometries()
 
     _, torsions = find_terminal_torsions(conformer)
-    chiral_centers = conformer.chiral_centers
 
     torsion_angles = np.arange(0, 360, delta)
     torsion_combos = list(itertools.product(
@@ -98,9 +97,20 @@ def find_all_combos(
         cistrans_combos = [()]
 
     if chiral_centers:
+        chiral_centerss = []
         chiral_options = ["R", "S"]
+        try:
+            ring_info = conformer._pseudo_geometry.GetRingInfo()
+        except AttributeError:
+            ring_info = conformer.rdkit_molecule.GetRingInfo()
+
+        for center in conformer.chiral_centers:
+            if ring_info.NumAtomRings(center.atom_index) != 0:
+                continue
+            chiral_centerss.append(center)
+
         chiral_combos = list(itertools.product(
-            chiral_options, repeat=len(chiral_centers)))
+            chiral_options, repeat=len(chiral_centerss)))
 
     else:
         chiral_combos = [()]

--- a/autotst/conformer/systematic.py
+++ b/autotst/conformer/systematic.py
@@ -71,7 +71,6 @@ def find_all_combos(
     conformer.get_geometries()
 
     _, torsions = find_terminal_torsions(conformer)
-    cistranss = conformer.cistrans
     chiral_centers = conformer.chiral_centers
 
     torsion_angles = np.arange(0, 360, delta)
@@ -79,7 +78,19 @@ def find_all_combos(
         torsion_angles, repeat=len(torsions)))
 
     if cistrans:
+        cistranss = []
         cistrans_options = ["E", "Z"]
+        try:
+            ring_info = conformer._pseudo_geometry.GetRingInfo()
+        except AttributeError:
+            ring_info = conformer.rdkit_molecule.GetRingInfo()
+
+        for cistrans in conformer.cistrans:
+            i,j,k,l = cistrans.atom_indices
+            if (ring_info.NumAtomRings(i) != 0) or (ring_info.NumAtomRings(k) != 0):
+                continue
+            cistranss.append(cistrans)
+
         cistrans_combos = list(itertools.product(
             cistrans_options, repeat=len(cistranss)))
 


### PR DESCRIPTION
When I was digging into why AutoTST had a weirdly high failure rate for migration reactions, I dove into some of the results for the conformer analysis and saw conformers that look like the following:

For reaction 
![rxn](https://user-images.githubusercontent.com/20301547/84808708-15fdb780-afd7-11ea-94c0-6c88e5b7adba.png)

The conformer generation outputted this as one of the low energy conformers where the stars are the reacting atoms:

![Screen Shot 2020-06-16 at 1 38 39 PM](https://user-images.githubusercontent.com/20301547/84808757-2746c400-afd7-11ea-83a3-488c26420d07.png)

Diving into this I saw that one of the stared atoms is identified as a chiral center and is therefore inverted during the conformer generation process and this flips the geometry out of its ring-like TS. This PR will ignore chiral centers and CisTrans bonds in rings by looking at the `_pseudo_geometry` which has a fake single bond drawn between reacting atoms. An example of what the `_pseudo_geometry` looks like is below.

![Screen Shot 2020-06-16 at 1 45 43 PM](https://user-images.githubusercontent.com/20301547/84809205-bbb12680-afd7-11ea-8545-8a77150a6783.png)
 
