### PR TITLE
[WIP] Hindered Rotor Approximation

### DIFF
--- a/autotst/calculator/statmech.py
+++ b/autotst/calculator/statmech.py
@@ -438,7 +438,7 @@ class StatMech():
             f.write(input_string)
         return True
 
-    def write_kinetics_input(self, include_rotors=True):
+    def write_kinetics_input(self, include_rotors=False):
         """
         A method to write Arkane file to obtain kinetics for a Reaction object
 

--- a/autotst/calculator/statmech.py
+++ b/autotst/calculator/statmech.py
@@ -746,6 +746,33 @@ class StatMech():
         Ea = B / constants.R
         return Arrhenius(A=(A, 'cm^3/(mol*s)'), n=n, Ea=(Ea, 'J/mol'))
 
+    def calculate_free_rotor_partition_function(self, arkane_conformer, conformer, torsion_index, temperature):
+        """
+        A method to calculate the partition function of a free rotor. This is based on 
+        equation 2.17 from `Thermochemical Kinetics: Methods for the Estimation 
+        of Thermochemical Data and Rate Parameters` by Sidney W. Benson.
+        
+        Inputs:
+        - arkane_conformer (rmgpy.statmech.conformer.Conformer): an RMG conformer
+            of interest
+        - conformer (autotst.species.Conformer): an AutoTST conformer object 
+        - torsion_index (int): the index of the torsion we want to calculate the
+            partition function for
+        - temperature (float): the temperature we want to calculate the partition fucntion at
+        
+        Returns:
+        - Q (float): the partition function of the free rotor
+        """
+        torsion = conformer.torsions[torsion_index]
+        i,j,k,l = np.array(torsion.atom_indices) + 1
+        top1 = np.arange(len(torsion.mask))[torsion.mask] + 1
+
+        I = calculate_I(conformer, torsion_index, arkane_conformer)
+        
+        symm = symmetry(conformer, torsion_index)
+
+        return (constants.pi**0.5 / symm) * ((8*constants.pi*I*constants.kB*temperature) / constants.h**2)** 0.5
+
     def set_results(self):
         """
         A method to set the RMGReaction from the kinetics job to the RMGReaction of the input Reaction

--- a/autotst/calculator/statmech.py
+++ b/autotst/calculator/statmech.py
@@ -45,6 +45,8 @@ import arkane.thermo
 import arkane.kinetics
 import arkane.statmech
 
+from arkane.ess.gaussian import GaussianLog
+
 FORMAT = "%(filename)s:%(lineno)d %(funcName)s %(levelname)s %(message)s"
 logging.basicConfig(format=FORMAT, level=logging.INFO)
 
@@ -129,6 +131,28 @@ def build_hr_interpolations():
     n_interpolation = interp2d(barriers, partition, n)
     B_interpolation = interp2d(barriers, partition, B)
     return (loga_interpolation, n_interpolation, B_interpolation)
+
+def read_arkane_conformer(path):
+    """
+    Given a path to a Gaussian log file, reads it in and returns 
+    a RMG / Arkane conformer which will be used in other functions
+    
+    Inputs:
+    - path (str): the path to the log file
+    
+    Returns:
+    - arkane_conformer (rmgpy.statmech.conformer.Conformer):
+        the RMG conformer corresponding to the log file 
+    """
+    log = GaussianLog(path)
+    arkane_conformer, *_ = log.load_conformer()
+    coords, numbers, mass = log.load_geometry()
+
+    arkane_conformer.coordinates = (coords * 10 ** -10, 'm')
+    arkane_conformer.number = numbers
+    arkane_conformer.mass = (mass, 'amu')
+    
+    return arkane_conformer
 
 class StatMech():
 

--- a/autotst/calculator/statmech.py
+++ b/autotst/calculator/statmech.py
@@ -666,6 +666,39 @@ class StatMech():
             elif isinstance(self.kinetics_job, arkane.thermo.ThermoJob):
                 self.thermo_job = job
 
+
+    def estimate_rotational_barrier(self, conformer, torsion_index):
+        """
+        A method to quickly estimate the barrier to internal rotation for complexes.
+        This rule of thumb was taken from the textbook: Section 2.9 of `Thermochemical 
+        Kinetics: Methods for the Estimation of Thermochemical Data and Rate Parameters` 
+        by Sidney W. Benson.
+        
+        
+        Inputs:
+        - conformer (autotst.species.Conformer): the conformer of interest
+        - torsion_index (int): the index corresponding to the rotor of interest
+        
+        Returns:
+        - estimated_barrier (float): the estimated barrier to rotation in kcal
+        """
+        
+        # Keys are number of substituents
+        # Values are barriers in kcal
+        ESTIMATED_BARRIERS = {
+            0: 0,
+            1: 1.1,
+            2: 2.2,
+            3: 3.5
+        }
+        
+        torsion = conformer.torsions[torsion_index]
+        i,j,k,l = torsion.atom_indices
+        j_neighbors = len(conformer.rmg_molecule.atoms[j].bonds) - 1
+        k_neighbors = len(conformer.rmg_molecule.atoms[k].bonds) - 1
+    
+        return ESTIMATED_BARRIERS[min([j_neighbors, k_neighbors])]
+
     def find_closest_vibrational_arrhenius(self, w):
         """
         A method that will find the arrhenius expression corresponding to 

--- a/autotst/calculator/statmech.py
+++ b/autotst/calculator/statmech.py
@@ -157,6 +157,24 @@ def read_arkane_conformer(path):
     
     return arkane_conformer
 
+def approximate_vibration(Q, V, T):
+    '''
+    A way to approximate the RRHO vibration corresponding to
+    a hindered rotor contribution. Based on equation 27 from 
+    `Predicting the Preexponential Temperature Dependence of 
+    Bimolecular Metathesis Reaction Rate Coeffieicents using 
+    Transition State Theory` by N. Cohen, 1989
+    
+    Inputs:
+    - Q (float): the free rotor partition function
+    - V (float): the barrier to rotation in kcal
+    - T (float): the temperature of interest
+    
+    Returns:
+    - w (float): the approximate vibration
+    '''
+    return 360 * (T / 298) * (1/Q) * (V / (constants.R / 4184 * T))**0.5
+
 class StatMech():
 
     def __init__(
@@ -767,9 +785,9 @@ class StatMech():
         i,j,k,l = np.array(torsion.atom_indices) + 1
         top1 = np.arange(len(torsion.mask))[torsion.mask] + 1
 
-        I = calculate_I(conformer, torsion_index, arkane_conformer)
+        I = conformer.get_internal_reduced_moment_of_inertia(torsion_index, arkane_conformer)
         
-        symm = symmetry(conformer, torsion_index)
+        symm = conformer.get_bond_symmetry(torsion_index)
 
         return (constants.pi**0.5 / symm) * ((8*constants.pi*I*constants.kB*temperature) / constants.h**2)** 0.5
 

--- a/autotst/calculator/statmech_test.py
+++ b/autotst/calculator/statmech_test.py
@@ -167,16 +167,11 @@ class TestStatMech(unittest.TestCase):
     def test_set_results(self):
         self.test_run()
         self.statmech.set_results()
-        self.assertTrue(
-            self.reaction.rmg_reaction.is_isomorphic(
-                self.statmech.kinetics_job.reaction
-            )
-        )
-        self.assertTrue(
-            self.statmech.reaction.rmg_reaction.is_isomorphic(
-                self.statmech.kinetics_job.reaction
-            )
-        )
+        reactions = [self.reaction.rmg_reaction, self.statmech.reaction.rmg_reaction]
+        for reaction in reactions:
+            self.assertTrue(self.statmech.kinetics_job.reaction.is_isomorphic(
+                reaction
+            ))
 
     def test_build_interpolation1(self):
         vib_interpolation = build_vibrational_interpolation()

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -1132,3 +1132,35 @@ class Conformer():
             self._symmetry_number = mol.get_symmetry_number() 
 
         return self._symmetry_number
+
+    def get_internal_reduced_moment_of_inertia(self, torsion_index, arkane_conformer):
+        """
+        This method uses an RMG-Py conformer object and the torsion inforamtion
+        to calculate the internal ruduced moment of interia. This is used
+        in Statmech when calculating the rotational partition function.
+        """
+        torsion = self.torsions[torsion_index]
+        i,j,k,l = np.array(torsion.atom_indices) + 1
+        top1 = np.arange(len(torsion.mask))[torsion.mask] +1
+
+        I = arkane_conformer.get_internal_reduced_moment_of_inertia((j,k), list(top1))
+        return I
+
+    def get_bond_symmetry(self, torsion_index):
+        """
+        This method used RMG-Py to calculate the bond symmetry for a conformer. 
+        If it's unable to calcuate the bond symmetry because of a KeyError
+        (often seen when calculating bonds symmetry around reaction centers), 
+        it will return a symmetry of 1.
+        """
+        from rmgpy.molecule.symmetry import calculate_bond_symmetry_number
+        try:
+            torsion = self.torsions[torsion_index]
+            i,j,k,l = np.array(torsion.atom_indices)
+            symm = calculate_bond_symmetry_number(
+                self.rmg_molecule, 
+                self.rmg_molecule.atoms[j], 
+                self.rmg_molecule.atoms[k])
+        except KeyError:
+            symm = 1.0
+        return symm

--- a/autotst/species_test.py
+++ b/autotst/species_test.py
@@ -40,6 +40,7 @@ import rmgpy.molecule
 import autotst
 from .geometry import Bond, Angle, Torsion, CisTrans, ChiralCenter
 from .species import Species, Conformer
+from .calculator.statmech import read_arkane_conformer
 
 class TestConformer(unittest.TestCase):
     def setUp(self):
@@ -106,6 +107,16 @@ class TestConformer(unittest.TestCase):
         for n in range(len(positions)):
             self.assertTrue((np.array([float(x) for x in xyz_block.split('\n')[n].split()[1:]]) == positions[n]).all())
 
+    def test_get_internal_reduced_moment_of_inertia(self):
+        path = os.path.expandvars('$AUTOTST/test/bin/log-files/CC_0.log')
+        arkane_conformer =  read_arkane_conformer(path)
+        I = self.conformer.get_internal_reduced_moment_of_inertia(0, arkane_conformer)
+        self.assertAlmostEqual(I, 2.0e-47, -46)
+
+    def test_get_bond_symmetry(self):
+        symm = self.conformer.get_bond_symmetry(0)
+        self.assertEqual(symm, 2.0)
+    
 class TestSpecies(unittest.TestCase):
     def setUp(self):
         self.species = Species(smiles=["CC"])


### PR DESCRIPTION
This PR makes use of Cohen's hindered rotor approximations from his 1989 paper "Predicting the Preexponential Temperature Dependence of Bimolecular Metathesis Reaction Rate Coefficients using Transition State Theory" as a post-processing step when determining kinetics. This approximation essentially removed the RRHO contribution to the rate expression and includes the 1DHR contribution to the rate constant. This works by using an estimate of the barrier height and the calculated free rotor partition function to determine the RRHO and 1DHR contributions over a set of temperatures and either multiplies or divides the contribution by the original rate expression. 

