### PR TITLE
Minor: Correct a typo in a warning message that causes an error

### DIFF
--- a/autotst/data/base.py
+++ b/autotst/data/base.py
@@ -689,7 +689,7 @@ class TSGroups(rmgpy.data.base.Database):
         # matched
         if len(template) != len(forward_template):
             logging.warning(
-                f'Unable to find matching template for reaction {reactin!s} in reaction family {self!s}')
+                f'Unable to find matching template for reaction {reaction!s} in reaction family {self!s}')
             logging.warning(" Trying to match " + str(forward_template))
             logging.warning(" Matched " + str(template))
             print(str(self), template, forward_template)


### PR DESCRIPTION
A logging warning in data/base.py had a wrong argument name ("reactin"), which caused AutoTST to crush instead of warning the user.