### PR TITLE
Smiles parse

### DIFF
--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -31,6 +31,7 @@
 import os, itertools, logging
 import numpy as np
 from copy import deepcopy
+import re
 
 import rdkit
 import rdkit.Chem 
@@ -323,12 +324,16 @@ class Reaction():
             smiles_conversions = {
                 "[CH]":"[CH...]"
             }
+
             def get_rmg_mol(smile):
                 if smile.upper() in list(smiles_conversions.keys()):
                     smile = smiles_conversions[smile.upper()]
                 return rmgpy.molecule.Molecule(smiles=smile).generate_resonance_structures()
-            rmg_reactants = [get_rmg_mol(smile) for smile in r.split("+")]
-            rmg_products = [get_rmg_mol(smile) for smile in p.split("+")]
+            # regex split at a '+' but make sure there isn't a ']' after it
+            r_smiles = re.split(r"\+(?![^\[]*\])", r)
+            p_smiles = re.split(r"\+(?![^\[]*\])", p)
+            rmg_reactants = [get_rmg_mol(smile) for smile in r_smiles]
+            rmg_products = [get_rmg_mol(smile) for smile in p_smiles]
 
             combos_to_try = list(itertools.product(
                 list(itertools.product(*rmg_reactants)),

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,4 @@ dependencies:
   - rmg::rdkit >= 2019.03.4
   - codecov
   - nose
-  - matplotlib == 3.1.1
+  - matplotlib


### PR DESCRIPTION
- I have removed the requirement of matplotlib as the current version 3.1.1 returns the following error:
 
```
Bad key animation.avconv_path in file /home/calvin.p/mambaforge/envs/tst_env/lib/python3.7/site-packages/matplotlib/mpl-data/stylelib/_classic_test.mplstyle, line 477 ('animation.avconv_path: avconv     # Path to avconv binary. Without full path')
You probably need to get an updated matplotlibrc file from
https://github.com/matplotlib/matplotlib/blob/v3.5.3/matplotlibrc.template
or from the matplotlib source distribution
 ```
Unrestricting the version number updates it to 3.5.3 which then removes this error

- Changes have been made to how AutoTST splits the reactant smiles as well as the product smiles. It was noticed that there was a smiles parse error for certain reactions, for example:

```
AutoTST reaction label: [N]=N+NN_[N-]=[NH2+]+[NH]N
```

When it would split the reactant smiles, the result would be:

```
[N-]=[NH2
```

Therefore, the addition of the regex pattern will now ensure that if there is a `+`, it is not proceeded by a `]`