### PR TITLE
Locked ASE to 3.22.1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
 dependencies:
   - python
   - rmg::rmg == 3.0.0
-  - conda-forge::ase
+  - conda-forge::ase == 3.22.1
   - conda-forge::cclib >= 1.7.0
   - conda-forge::py3dmol
   - rmg::rdkit >= 2019.03.4


### PR DESCRIPTION
ASE was not locked before, so the environment would install 3.23.0. However, this version (although not explicitly stated) requires python3.8. Since AutoTST is locked to python3.7, therefore we need to keep the ASE version that is appropriate for Python3.7