### PR TITLE
Specify random seed to make RDKit embedding deterministic

### DIFF
--- a/autotst/reaction.py
+++ b/autotst/reaction.py
@@ -916,7 +916,7 @@ class TS(Conformer):
         """
         num_conf_attempts = 10000
         if (self.bm is None) or (self.atom_match is None):
-            rdkit.Chem.AllChem.EmbedMultipleConfs(self._rdkit_molecule, num_conf_attempts, randomSeed=1)
+            rdkit.Chem.AllChem.EmbedMultipleConfs(self._rdkit_molecule, num_conf_attempts, randomSeed=400)
 
             self._rdkit_molecule, minEid = self.optimize_rdkit_molecule()
         else:
@@ -927,7 +927,7 @@ class TS(Conformer):
             self._rdkit_molecule.RemoveAllConformers()
             for i in range(0, num_conf_attempts):
                 try:
-                    rdkit.Chem.Pharm3D.EmbedLib.EmbedMol(self._rdkit_molecule, self.bm, atomMatch=self.atom_match)
+                    rdkit.Chem.Pharm3D.EmbedLib.EmbedMol(self._rdkit_molecule, self.bm, atomMatch=self.atom_match, randomSeed=400)
                     break
                 except ValueError:
                     logging.info(

--- a/autotst/reaction_test.py
+++ b/autotst/reaction_test.py
@@ -30,6 +30,7 @@
 
 import os, sys
 import unittest
+import numpy as np
 import ase
 import rdkit.Chem.rdchem
 import rmgpy.reaction
@@ -211,6 +212,16 @@ class TestReaction(unittest.TestCase):
         _, family = reaction.get_labeled_reaction()
         self.assertEqual(family.lower(), "intra_H_migration".lower())
 
+    def test_initial_ts_geometry_is_deterministic(self):
+        list_of_coords = []
+        my_reaction_smiles = 'CCCC+[OH]_O+[CH2]CCC'
+        for i in range(3):
+            my_reaction = Reaction(label=my_reaction_smiles)
+            list_of_coords.append(my_reaction.ts['forward'][0].ase_molecule)
+
+        for i in range(1, 3):
+            self.assertTrue(np.all(list_of_coords[i].positions == list_of_coords[0].positions))
+
 class TestTS(unittest.TestCase):
 
     def setUp(self):
@@ -242,7 +253,7 @@ class TestTS(unittest.TestCase):
         self.assertIsInstance(rdkit_molecule, rdkit.Chem.rdchem.Mol)
         self.assertEquals(len(rdkit_molecule.GetAtoms()), 11)
         self.assertEquals(len(rdkit_molecule.GetBonds()), 9)
-    
+
     def test_pseudo_geometry(self):
         self.assertIsInstance(self.ts._pseudo_geometry, rdkit.Chem.rdchem.RWMol)
         self.assertEquals(len(self.ts._pseudo_geometry.GetBonds()), 10)

--- a/autotst/species.py
+++ b/autotst/species.py
@@ -278,7 +278,7 @@ class Conformer():
         assert self.rmg_molecule, "Cannot create an RDKit geometry without an RMG molecule object"
 
         RDMol = self.rmg_molecule.to_rdkit_mol(remove_h=False)
-        rdkit.Chem.AllChem.EmbedMolecule(RDMol)
+        rdkit.Chem.AllChem.EmbedMolecule(RDMol, randomSeed=400)
         self._rdkit_molecule = RDMol
 
         mol_list = rdkit.Chem.AllChem.MolToMolBlock(self.rdkit_molecule).split('\n')
@@ -1093,7 +1093,7 @@ class Conformer():
         rdmol.GetAtomWithIdx(chiral_center.atom_index).SetChiralTag(
             centers_dict[stero.upper()])
 
-        rdkit.Chem.rdDistGeom.EmbedMolecule(rdmol)
+        rdkit.Chem.rdDistGeom.EmbedMolecule(rdmol, randomSeed=400)
 
         old_torsions = self.torsions[:] + self.cistrans[:]
 


### PR DESCRIPTION
## Overview

The geometries for conformer generation aren't deterministic: https://github.com/ReactionMechanismGenerator/AutoTST/issues/94

I added a random seed so that every time you generate a species conformer, TS, or set the chirality, you will get the same result.

This is important if you want to generate conformers in AutoTST and then go back and analyze them later. If you want to rebuild the AutoTST species objects in memory, you want to get the same result each time.

## Testing
Here's the code I used to test species conformers:
```
all_atoms = ase.Atoms()
for i in range(3):
    my_species = autotst.species.Species(smiles=['CCCC'])
    all_atoms += my_species.conformers['CCCC'][0].get_ase_mol()
    
ase.visualize.view(all_atoms, viewer='x3d')
```


And setting the chirality:
```
# need chiral center example
all_atoms = ase.Atoms()
for i in range(10):

    my_chiral_smiles = 'ClC=C(C(Cl)N)O'
    my_chiral_species = autotst.species.Species(smiles=[my_chiral_smiles])
    
    chiral_centers = my_chiral_species.conformers[my_chiral_smiles][0].get_chiral_centers()
    my_chiral_species.conformers[my_chiral_smiles][0].set_chirality(chiral_centers[0].index, 'R')
    
    all_atoms += my_chiral_species.conformers[my_chiral_smiles][0].get_ase_mol()
  
ase.visualize.view(all_atoms, viewer='x3d')
```

And making the TS object:
```
all_atoms = ase.Atoms()
my_reaction_smiles = 'CCCC+[OH]_O+[CH2]CCC'
for i in range(5):
    
    my_reaction = autotst.reaction.Reaction(label=my_reaction_smiles)
    my_reaction.ts

    all_atoms += my_reaction.ts['forward'][0].ase_molecule
```